### PR TITLE
[fix] 기존 예외처리 개편했습니다. 

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
@@ -39,14 +39,5 @@ public class ErrorResponseDTO {
         );
     }
 
-    public static ErrorResponseDTO error(MethodArgumentNotValidException e) {
-        List<String> msgList = e.getAllErrors().stream()
-                .map(DefaultMessageSourceResolvable::getDefaultMessage)
-                .collect(Collectors.toList());
-
-        return new ErrorResponseDTO(
-                BAD_REQUEST.getStatus(), BAD_REQUEST.getCode(), String.join(", ", msgList)
-        );
-    }
 
 }

--- a/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
@@ -45,9 +45,8 @@ public class ErrorResponseDTO {
                 .collect(Collectors.toList());
 
         return new ErrorResponseDTO(
-                BAD_REQUEST.getStatus(), BAD_REQUEST.getCode(), String.join(", ",msgList)
+                BAD_REQUEST.getStatus(), BAD_REQUEST.getCode(), String.join(", ", msgList)
         );
-
     }
 
 }

--- a/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
@@ -1,24 +1,35 @@
 package com.fastcampus.toyproject.common.dto;
 
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.INTERNAL_SERVER_ERROR;
+import static com.fastcampus.toyproject.common.exception.DefaultExceptionCode.INTERNAL_SERVER_ERROR;
 
+import com.fastcampus.toyproject.common.exception.DefaultExceptionCode;
 import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public class ErrorResponseDTO {
 
-    private final ExceptionCode exceptionCode;
-    private final String errorMsg;
+    private final HttpStatus status;
+    private final String code;
+    private final String msg;
 
-    public static ErrorResponseDTO error(ExceptionCode exceptionCode, String errorMsg) {
-        return new ErrorResponseDTO(exceptionCode, errorMsg);
+    public static ErrorResponseDTO error(ExceptionCode exceptionCode) {
+        return new ErrorResponseDTO(
+                exceptionCode.getStatus(),
+                exceptionCode.getCode(),
+                exceptionCode.getMsg()
+        );
     }
 
     public static ErrorResponseDTO error() {
-        return new ErrorResponseDTO(INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR.getMsg());
+        return new ErrorResponseDTO(
+                INTERNAL_SERVER_ERROR.getStatus(),
+                INTERNAL_SERVER_ERROR.getCode(),
+                INTERNAL_SERVER_ERROR.getMsg()
+        );
     }
 
 

--- a/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
@@ -1,12 +1,19 @@
 package com.fastcampus.toyproject.common.dto;
 
+import static com.fastcampus.toyproject.common.exception.DefaultExceptionCode.BAD_REQUEST;
 import static com.fastcampus.toyproject.common.exception.DefaultExceptionCode.INTERNAL_SERVER_ERROR;
 
-import com.fastcampus.toyproject.common.exception.DefaultExceptionCode;
 import com.fastcampus.toyproject.common.exception.ExceptionCode;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 @Getter
 @RequiredArgsConstructor
@@ -32,5 +39,15 @@ public class ErrorResponseDTO {
         );
     }
 
+    public static ErrorResponseDTO error(MethodArgumentNotValidException e) {
+        List<String> msgList = e.getAllErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.toList());
+
+        return new ErrorResponseDTO(
+                BAD_REQUEST.getStatus(), BAD_REQUEST.getCode(), String.join(", ",msgList)
+        );
+
+    }
 
 }

--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultException.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultException.java
@@ -1,20 +1,22 @@
 package com.fastcampus.toyproject.common.exception;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class DefaultException extends RuntimeException {
 
     ExceptionCode errorCode;
     String errorMsg;
 
-    public DefaultException(ExceptionCode errorCode, String errorMsg) {
+    public DefaultException(DefaultExceptionCode errorCode, String errorMsg) {
         super(errorCode.getMsg());
         this.errorCode = errorCode;
         this.errorMsg = errorMsg;
     }
 
-    public DefaultException(ExceptionCode errorCode) {
+    public DefaultException(DefaultExceptionCode errorCode) {
         super(errorCode.getMsg());
         this.errorCode = errorCode;
         this.errorMsg = errorCode.getMsg();

--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionCode.java
@@ -1,0 +1,22 @@
+package com.fastcampus.toyproject.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum DefaultExceptionCode implements ExceptionCode {
+
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR" ,"서버에 오류가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 입력값 입니다."),
+    STARTDATE_IS_LATER_THAN_ENDDATE(HttpStatus.BAD_REQUEST, "STARTDATE_IS_LATER_THAN_ENDDATE", "출발 일정이 도착 일정보다 늦습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String msg;
+
+
+}

--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
@@ -7,8 +7,11 @@ import com.fastcampus.toyproject.common.dto.ResponseDTO;
 import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
 import com.fastcampus.toyproject.domain.trip.exception.TripException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -93,8 +96,14 @@ public class DefaultExceptionHandler {
                 e.getMessage()
         );
 
+        List<String> msgList = e.getAllErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.toList());
+
         return new ResponseEntity<>(
-                ErrorResponseDTO.error(e),
+                new ErrorResponseDTO(
+                        BAD_REQUEST.getStatus(), BAD_REQUEST.getCode(), String.join(", ", msgList)
+                ),
                 HttpStatus.BAD_REQUEST
         );
     }

--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
@@ -1,8 +1,9 @@
 package com.fastcampus.toyproject.common.exception;
 
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.BAD_REQUEST;
+import static com.fastcampus.toyproject.common.exception.DefaultExceptionCode.BAD_REQUEST;
 
 import com.fastcampus.toyproject.common.dto.ErrorResponseDTO;
+import com.fastcampus.toyproject.common.dto.ResponseDTO;
 import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
 import com.fastcampus.toyproject.domain.trip.exception.TripException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -28,23 +29,22 @@ public class DefaultExceptionHandler {
      * @return
      */
     @ExceptionHandler(
-        value = {TripException.class, ItineraryException.class, DefaultException.class})
+        value = {TripException.class, ItineraryException.class,
+                DefaultException.class, RuntimeException.class})
     public ResponseEntity<ErrorResponseDTO> handleDefaultException(
         DefaultException e,
         HttpServletRequest request
     ) {
-        log.error("error!!!! errorCode : {}, url : {}, message : {}, trace : {}",
-            e.getErrorCode(),
-            e.getErrorMsg(),
-            request.getRequestURI(),
-            e.getStackTrace()
+        log.error("error!!!! status : {} , errorCode : {}, message : {}, url : {}",
+            e.getErrorCode().getStatus(),
+            e.getErrorCode().getCode(),
+            e.getErrorCode().getMsg(),
+            request.getRequestURI()
         );
 
         return new ResponseEntity<>(
-            ErrorResponseDTO.error(
-                e.getErrorCode(),
-                e.getMessage()),
-            HttpStatus.CONFLICT
+                ErrorResponseDTO.error(e.getErrorCode()),
+                e.getErrorCode().getStatus()
         );
     }
 
@@ -69,11 +69,10 @@ public class DefaultExceptionHandler {
             e.getMessage()
         );
 
+        ExceptionCode badError = BAD_REQUEST;
+
         return new ResponseEntity<>(
-            ErrorResponseDTO.error(
-                BAD_REQUEST,
-                BAD_REQUEST.getMsg()
-            ),
+            ErrorResponseDTO.error(badError),
             HttpStatus.BAD_REQUEST
 
         );
@@ -92,8 +91,10 @@ public class DefaultExceptionHandler {
             e.getStackTrace()
         );
 
+        ExceptionCode serverError = DefaultExceptionCode.INTERNAL_SERVER_ERROR;
+
         return new ResponseEntity<>(
-            ErrorResponseDTO.error(),
+            ErrorResponseDTO.error(serverError),
             HttpStatus.INTERNAL_SERVER_ERROR
         );
     }

--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
@@ -76,13 +76,19 @@ public class DefaultExceptionHandler {
         );
     }
 
+    /**
+     * @Valid 를 통해 나타나는 예외 처리
+     * @param e
+     * @param request
+     * @return
+     */
     @ExceptionHandler(value = {
             MethodArgumentNotValidException.class
     })
     public ResponseEntity<ErrorResponseDTO> handleArgumentNotVaildException(
             MethodArgumentNotValidException e, HttpServletRequest request
     ) {
-        log.error("request error url : {}, message : {}",
+        log.error("MethodArgumentNotValid error url : {}, message : {}",
                 request.getRequestURI(),
                 e.getMessage()
         );
@@ -92,6 +98,13 @@ public class DefaultExceptionHandler {
                 HttpStatus.BAD_REQUEST
         );
     }
+
+    /**
+     * 기타 예외 처리
+     * @param e
+     * @param request
+     * @return
+     */
 
     @ExceptionHandler(value = {
         Exception.class

--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.fastcampus.toyproject.common.exception;
 
 import static com.fastcampus.toyproject.common.exception.DefaultExceptionCode.BAD_REQUEST;
+import static com.fastcampus.toyproject.common.exception.DefaultExceptionCode.INTERNAL_SERVER_ERROR;
 
 import com.fastcampus.toyproject.common.dto.ErrorResponseDTO;
 import com.fastcampus.toyproject.common.dto.ResponseDTO;
@@ -116,7 +117,7 @@ public class DefaultExceptionHandler {
      */
 
     @ExceptionHandler(value = {
-        Exception.class
+        Exception.class, NullPointerException.class
     })
     public ResponseEntity<ErrorResponseDTO> handleException(
         Exception e, HttpServletRequest request
@@ -128,10 +129,8 @@ public class DefaultExceptionHandler {
             e.getStackTrace()
         );
 
-        ExceptionCode serverError = DefaultExceptionCode.INTERNAL_SERVER_ERROR;
-
         return new ResponseEntity<>(
-            ErrorResponseDTO.error(serverError),
+            ErrorResponseDTO.error(INTERNAL_SERVER_ERROR),
             HttpStatus.INTERNAL_SERVER_ERROR
         );
     }

--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
@@ -58,7 +58,6 @@ public class DefaultExceptionHandler {
     @ExceptionHandler(value = {
         HttpRequestMethodNotSupportedException.class,
         HttpMessageNotReadableException.class,
-        MethodArgumentNotValidException.class,
         InvalidFormatException.class
     })
     public ResponseEntity<ErrorResponseDTO> handleBadRequest(
@@ -74,7 +73,23 @@ public class DefaultExceptionHandler {
         return new ResponseEntity<>(
             ErrorResponseDTO.error(badError),
             HttpStatus.BAD_REQUEST
+        );
+    }
 
+    @ExceptionHandler(value = {
+            MethodArgumentNotValidException.class
+    })
+    public ResponseEntity<ErrorResponseDTO> handleArgumentNotVaildException(
+            MethodArgumentNotValidException e, HttpServletRequest request
+    ) {
+        log.error("request error url : {}, message : {}",
+                request.getRequestURI(),
+                e.getMessage()
+        );
+
+        return new ResponseEntity<>(
+                ErrorResponseDTO.error(e),
+                HttpStatus.BAD_REQUEST
         );
     }
 

--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
@@ -34,7 +34,7 @@ public class DefaultExceptionHandler {
      */
     @ExceptionHandler(
         value = {TripException.class, ItineraryException.class,
-                DefaultException.class, RuntimeException.class})
+                DefaultException.class})
     public ResponseEntity<ErrorResponseDTO> handleDefaultException(
         DefaultException e,
         HttpServletRequest request
@@ -117,7 +117,7 @@ public class DefaultExceptionHandler {
      */
 
     @ExceptionHandler(value = {
-        Exception.class, NullPointerException.class
+        Exception.class, RuntimeException.class
     })
     public ResponseEntity<ErrorResponseDTO> handleException(
         Exception e, HttpServletRequest request

--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
@@ -32,9 +32,9 @@ public class DefaultExceptionHandler {
      * @param request
      * @return
      */
-    @ExceptionHandler(
-        value = {TripException.class, ItineraryException.class,
-                DefaultException.class})
+    @ExceptionHandler(value = {
+        TripException.class, ItineraryException.class, DefaultException.class
+    })
     public ResponseEntity<ErrorResponseDTO> handleDefaultException(
         DefaultException e,
         HttpServletRequest request
@@ -85,7 +85,7 @@ public class DefaultExceptionHandler {
      * @return
      */
     @ExceptionHandler(value = {
-            MethodArgumentNotValidException.class
+        MethodArgumentNotValidException.class
     })
     public ResponseEntity<ErrorResponseDTO> handleArgumentNotVaildException(
             MethodArgumentNotValidException e, HttpServletRequest request

--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
@@ -72,10 +72,8 @@ public class DefaultExceptionHandler {
             e.getMessage()
         );
 
-        ExceptionCode badError = BAD_REQUEST;
-
         return new ResponseEntity<>(
-            ErrorResponseDTO.error(badError),
+            ErrorResponseDTO.error(BAD_REQUEST),
             HttpStatus.BAD_REQUEST
         );
     }
@@ -103,7 +101,9 @@ public class DefaultExceptionHandler {
 
         return new ResponseEntity<>(
                 new ErrorResponseDTO(
-                        BAD_REQUEST.getStatus(), BAD_REQUEST.getCode(), String.join(", ", msgList)
+                        BAD_REQUEST.getStatus(),
+                        BAD_REQUEST.getCode(),
+                        String.join(", ", msgList)
                 ),
                 HttpStatus.BAD_REQUEST
         );

--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
@@ -33,13 +33,13 @@ public class DefaultExceptionHandler {
      * @return
      */
     @ExceptionHandler(value = {
-        TripException.class, ItineraryException.class, DefaultException.class
+        DefaultException.class
     })
     public ResponseEntity<ErrorResponseDTO> handleDefaultException(
         DefaultException e,
         HttpServletRequest request
     ) {
-        log.error("error!!!! status : {} , errorCode : {}, message : {}, url : {}",
+        log.error("custom error!!!! status : {} , errorCode : {}, message : {}, url : {}",
             e.getErrorCode().getStatus(),
             e.getErrorCode().getCode(),
             e.getErrorCode().getMsg(),

--- a/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
@@ -1,19 +1,9 @@
 package com.fastcampus.toyproject.common.exception;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
-@AllArgsConstructor
-@Getter
-public enum ExceptionCode {
-
-
-    INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다."),
-    BAD_REQUEST("잘못된 입력값 입니다."),
-    INVALID_REQUEST("잘못된 요청입니다."),
-    STARTDATE_IS_LATER_THAN_ENDDATE("출발 일정이 도착 일정보다 늦습니다."),
-
-    ;
-
-    private final String msg;
+public interface ExceptionCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMsg();
 }

--- a/src/main/java/com/fastcampus/toyproject/common/util/DateUtil.java
+++ b/src/main/java/com/fastcampus/toyproject/common/util/DateUtil.java
@@ -1,6 +1,6 @@
 package com.fastcampus.toyproject.common.util;
 
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.STARTDATE_IS_LATER_THAN_ENDDATE;
+import static com.fastcampus.toyproject.common.exception.DefaultExceptionCode.STARTDATE_IS_LATER_THAN_ENDDATE;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/main/java/com/fastcampus/toyproject/common/util/LocationUtil.java
+++ b/src/main/java/com/fastcampus/toyproject/common/util/LocationUtil.java
@@ -1,7 +1,7 @@
 package com.fastcampus.toyproject.common.util;
 
 import com.fastcampus.toyproject.common.exception.DefaultException;
-import com.fastcampus.toyproject.common.exception.ExceptionCode;
+import com.fastcampus.toyproject.common.exception.DefaultExceptionCode;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -37,7 +37,7 @@ public class LocationUtil {
             return new URL(
                 baseUrl + URLEncoder.encode(location, StandardCharsets.UTF_8) + "&key=" + key);
         } catch (IOException e) {
-            throw new DefaultException(ExceptionCode.BAD_REQUEST);
+            throw new DefaultException(DefaultExceptionCode.BAD_REQUEST);
         }
     }
 
@@ -79,7 +79,7 @@ public class LocationUtil {
 
 
         } catch (IOException e) {
-            log.error(ExceptionCode.BAD_REQUEST.getMsg());
+            log.error(DefaultExceptionCode.BAD_REQUEST.getMsg());
             return location;
         }
     }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
@@ -1,7 +1,7 @@
 package com.fastcampus.toyproject.domain.itinerary.dto;
 
-import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.ILLEGAL_ARGUMENT_ARRIVALPLACE;
-import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.ILLEGAL_ARGUMENT_DEPARTUREPLACE;
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.EMPTY_ARRIVAL_PLACE;
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.EMPTY_DEPARTURE_PLACE;
 
 import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
 import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
@@ -42,10 +42,10 @@ public class ItineraryRequest {
 
     public String getMovementName() {
         if (this.departurePlace == null) {
-            throw new ItineraryException(ILLEGAL_ARGUMENT_DEPARTUREPLACE);
+            throw new ItineraryException(EMPTY_DEPARTURE_PLACE);
         }
         if (this.arrivalPlace == null) {
-            throw new ItineraryException(ILLEGAL_ARGUMENT_ARRIVALPLACE);
+            throw new ItineraryException(EMPTY_ARRIVAL_PLACE);
         }
         return this.departurePlace + " -> " + this.arrivalPlace;
     }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
@@ -21,19 +21,19 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class ItineraryRequest {
 
-    @NotNull
+    @NotNull(message = "여정 타입을 입력하세요. ")
     private ItineraryType type;
 
-    @NotNull
+    @NotNull(message = "여정 이름을 입력하세요. ")
     private String item;
 
-    @NotNull
+    @NotNull(message = "출발 날짜를 입력하세요.")
     private LocalDateTime startDate;
 
-    @NotNull
+    @NotNull(message = "도착 날짜를 입력하세요.")
     private LocalDateTime endDate;
 
-    @NotNull
+    @NotNull(message = "여정 순서를 입력하세요.")
     @Min(1)
     private Integer order;
 

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryException.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryException.java
@@ -1,22 +1,20 @@
 package com.fastcampus.toyproject.domain.itinerary.exception;
 
 
+import com.fastcampus.toyproject.common.exception.DefaultException;
+import com.fastcampus.toyproject.common.exception.DefaultExceptionCode;
+import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import lombok.Getter;
 
 @Getter
-public class ItineraryException extends RuntimeException {
+public class ItineraryException extends DefaultException {
 
-    ItineraryExceptionCode errorCode;
+    ExceptionCode errorCode;
     String errorMsg;
 
-    public ItineraryException(ItineraryExceptionCode errorCode, String errorMsg) {
-        super(errorCode.getMsg());
-        this.errorCode = errorCode;
-        this.errorMsg = errorMsg;
-    }
 
     public ItineraryException(ItineraryExceptionCode errorCode) {
-        super(errorCode.getMsg());
+        super();
         this.errorCode = errorCode;
         this.errorMsg = errorCode.getMsg();
     }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryExceptionCode.java
@@ -1,20 +1,28 @@
 package com.fastcampus.toyproject.domain.itinerary.exception;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
+
+import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 @Getter
-public enum ItineraryExceptionCode {
+public enum ItineraryExceptionCode implements ExceptionCode {
 
-    NO_ITINERARY("해당되는 여정이 없습니다."),
-    INCORRECT_ITNERARY_ORDER("잘못된 여정 순서입니다."),
-    DUPLICATE_ITINERARY_ORDER("여정 순서가 중복됩니다."),
-    EMPTY_ITINERARY("수정 할 여정 정보가 없습니다."),
-    ILLEGAL_ARGUMENT_DEPARTUREPLACE("출발지를 입력하지 않았습니다."),
-    ILLEGAL_ARGUMENT_ARRIVALPLACE("도착지를 입력하지 않았습니다."),
-    ILLEGAL_ITINERARY_TYPE("잘 못 된 여정 타입입니다."),
-    ITINERARY_ALREADY_DELETED("이미 삭제된 여정입니다.");
+    NO_ITINERARY(UNPROCESSABLE_ENTITY, "NO_ITINERARY", "해당되는 여정이 없습니다."),
+    INCORRECT_ITINERARY_ORDER(BAD_REQUEST, "INCORRECT_ITINERARY_ORDER", "잘못된 여정 순서입니다."),
+    DUPLICATE_ITINERARY_ORDER(BAD_REQUEST, "DUPLICATE_ITINERARY_ORDER","여정 순서가 중복됩니다."),
+    EMPTY_ITINERARY(BAD_REQUEST, "EMPTY_ITINERARY","수정 할 여정 정보가 없습니다."),
+    EMPTY_DEPARTURE_PLACE(BAD_REQUEST, "EMPTY_DEPARTURE_PLACE","출발지를 입력하지 않았습니다."),
+    EMPTY_ARRIVAL_PLACE(BAD_REQUEST, "EMPTY_ARRIVAL_PLACE","도착지를 입력하지 않았습니다."),
+    ILLEGAL_ITINERARY_TYPE(BAD_REQUEST, "ILLEGAL_ITINERARY_TYPE","잘 못 된 여정 타입입니다."),
+    ITINERARY_ALREADY_DELETED(BAD_REQUEST, "ITINERARY_ALREADY_DELETED","이미 삭제된 여정입니다.");
+
+    private final HttpStatus status;
+    private final String code;
     private final String msg;
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtil.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtil.java
@@ -1,7 +1,7 @@
 package com.fastcampus.toyproject.domain.itinerary.util;
 
 import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.DUPLICATE_ITINERARY_ORDER;
-import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.INCORRECT_ITNERARY_ORDER;
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.INCORRECT_ITINERARY_ORDER;
 
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
 import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
@@ -38,7 +38,7 @@ public class ItineraryOrderUtil {
         //2. 순서가 1부터 차례대로 들어갔는지 확인. (O(N))
         for (int orderIdx = 1; orderIdx <= orderList.size(); orderIdx++) {
             if (orderList.get(orderIdx - 1) != orderIdx) {
-                throw new ItineraryException(INCORRECT_ITNERARY_ORDER);
+                throw new ItineraryException(INCORRECT_ITINERARY_ORDER);
             }
         }
     }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripRequest.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripRequest.java
@@ -15,17 +15,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TripRequest {
 
-    @NotNull
+    @NotNull(message = "여행 이름을 입력하세요.")
     private String tripName;
 
-    @NotNull
+    @NotNull(message = "출발 날짜를 입력하세요.")
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate startDate;
 
-    @NotNull
+    @NotNull(message = "도착 날짜를 입력하세요.")
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;
 
-    @NotNull
+    @NotNull(message = "국내 여행 여부를 입력하세요.")
     private Boolean isDomestic;
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
@@ -22,6 +22,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.PrePersist;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -78,7 +79,6 @@ public class Trip {
     @Comment("국내여행 여부")
     private Boolean isDomestic;
 
-    //    @ColumnDefault("0") // 검색
     @Comment("좋아요 개수")
     private Integer likesCount;
 
@@ -94,6 +94,13 @@ public class Trip {
         this.startDate = tripDTO.getStartDate();
         this.endDate = tripDTO.getEndDate();
         this.isDomestic = tripDTO.getIsDomestic();
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (this.likesCount == null) {
+            this.likesCount = 0;
+        }
     }
 
 

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripException.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripException.java
@@ -1,22 +1,18 @@
 package com.fastcampus.toyproject.domain.trip.exception;
 
 
+import com.fastcampus.toyproject.common.exception.DefaultException;
+import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import lombok.Getter;
 
 @Getter
-public class TripException extends RuntimeException {
+public class TripException extends DefaultException {
 
-    TripExceptionCode errorCode;
+    ExceptionCode errorCode;
     String errorMsg;
 
-    public TripException(TripExceptionCode errorCode, String errorMsg) {
-        super(errorCode.getMsg());
-        this.errorCode = errorCode;
-        this.errorMsg = errorMsg;
-    }
-
     public TripException(TripExceptionCode errorCode) {
-        super(errorCode.getMsg());
+        super();
         this.errorCode = errorCode;
         this.errorMsg = errorCode.getMsg();
     }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripExceptionCode.java
@@ -1,13 +1,21 @@
 package com.fastcampus.toyproject.domain.trip.exception;
 
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
+
+import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 @Getter
-public enum TripExceptionCode {
-    NO_SUCH_TRIP("해당하는 Trip이 없습니다.");
+public enum TripExceptionCode implements ExceptionCode {
+    NO_SUCH_TRIP(UNPROCESSABLE_ENTITY, "NO_SUCH_TRIP", "해당하는 Trip이 없습니다."),
+    NOT_MATCH_BETWEEN_USER_AND_TRIP(UNPROCESSABLE_ENTITY, "NOT_MATCH_BETWEEN_USER_AND_TRIP", "유저의 여행 정보가 일치하지 않습니다.")
+    ;
 
+    private final HttpStatus status;
+    private final String code;
     private final String msg;
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
@@ -1,11 +1,12 @@
 package com.fastcampus.toyproject.domain.trip.service;
 
 
+import static com.fastcampus.toyproject.domain.trip.exception.TripExceptionCode.NOT_MATCH_BETWEEN_USER_AND_TRIP;
 import static com.fastcampus.toyproject.domain.trip.exception.TripExceptionCode.NO_SUCH_TRIP;
 
 import com.fastcampus.toyproject.common.BaseTimeEntity;
 import com.fastcampus.toyproject.common.exception.DefaultException;
-import com.fastcampus.toyproject.common.exception.ExceptionCode;
+import com.fastcampus.toyproject.common.exception.DefaultExceptionCode;
 import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
 import com.fastcampus.toyproject.domain.itinerary.service.ItineraryService;
 import com.fastcampus.toyproject.domain.trip.dto.TripDetailResponse;
@@ -14,7 +15,6 @@ import com.fastcampus.toyproject.domain.trip.dto.TripResponse;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fastcampus.toyproject.domain.trip.exception.TripException;
 import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
-import com.fastcampus.toyproject.domain.user.entity.User;
 import com.fastcampus.toyproject.domain.user.repository.UserRepository;
 import com.fastcampus.toyproject.domain.user.service.UserService;
 import java.util.List;
@@ -137,7 +137,7 @@ public class TripService {
         Trip existTrip = getTripByTripId(tripId);
 
         if (!existTrip.getUser().getUserId().equals(memberId)) {
-            throw new DefaultException(ExceptionCode.INVALID_REQUEST, "멤버의 여행 정보가 일치하지 않습니다.");
+            throw new TripException(NOT_MATCH_BETWEEN_USER_AND_TRIP);
         }
 
         existTrip.updateFromDTO(tripRequest);

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtilTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtilTest.java
@@ -1,7 +1,7 @@
 package com.fastcampus.toyproject.domain.itinerary.util;
 
 import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.DUPLICATE_ITINERARY_ORDER;
-import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.INCORRECT_ITNERARY_ORDER;
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.INCORRECT_ITINERARY_ORDER;
 
 import com.fastcampus.toyproject.common.exception.DefaultException;
 import java.time.LocalDateTime;
@@ -53,7 +53,7 @@ class ItineraryOrderUtilTest {
             ItineraryOrderUtil.validateItinerariesOrder(testList2);
         } catch (DefaultException e) {
             //where
-            Assertions.assertEquals(INCORRECT_ITNERARY_ORDER, e.getErrorCode());
+            Assertions.assertEquals(INCORRECT_ITINERARY_ORDER, e.getErrorCode());
         }
     }
 


### PR DESCRIPTION
## 개요
- 예외 처리 개편했습니다. 사용자가 직관적으로 에러를 확인할 수 있도록 바꿨습니다. 
- @valid 사용시 나타나는 에러들, 메시지 나오도록 수정했습니다. 
## 작업사항
## 변경로직
### 변경전
<img width="831" alt="스크린샷 2023-11-13 오전 1 07 50" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/59862752/81164275-2627-4c77-9698-7013abf91d6a">

사용자가 굳이 알 필요 없는 에러정보가 나타나는 상황을 수정하였습니다. 

### 변경후
<img width="907" alt="스크린샷 2023-11-13 오전 1 40 24" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/59862752/9e703cfa-0705-472a-b255-4490273faca2">
<img width="716" alt="스크린샷 2023-11-13 오전 1 09 51" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/59862752/0f686cf8-077e-4bea-b498-0121cd0cd86a">

<img width="723" alt="스크린샷 2023-11-13 오전 1 07 34" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/59862752/1414286a-17f5-4a4e-bfc2-5f0880f713f7">


## 사용방법

### 1. 커스텀 에러를 생성하고 싶다면, DefaultException을 상속받도록 해주세요! 
```java
@Getter
public class TripException extends DefaultException {

    ExceptionCode errorCode;
    String errorMsg;

    public TripException(TripExceptionCode errorCode) {
        super();
        this.errorCode = errorCode;
        this.errorMsg = errorCode.getMsg();
    }
}
``` 

### 2. 예외 코드를 추가하고 싶으시다면, 각 예외가 어떤 예외종류인지 (HttpStatus)도 추가해주세요

![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/59862752/03d14775-f4c7-4ee1-a9e4-dad8b9bae2ab)

