### PR TITLE
[feature] Spring Security 설정 및, 회원가입, 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,19 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	// https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	// https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-impl
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	// https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-jackson
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+
+
+
+
+
 	// Mockito dependencies
 	testImplementation 'org.mockito:mockito-core:4.1.0'
 	testImplementation 'org.mockito:mockito-junit-jupiter:4.1.0'

--- a/src/main/java/com/fastcampus/toyproject/config/security/SecurityUtil.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/SecurityUtil.java
@@ -1,0 +1,22 @@
+package com.fastcampus.toyproject.config.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtil {
+
+    private SecurityUtil() {};
+
+    public static Long getCurrentMemberId(){
+
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if(authentication == null || authentication.getName() == null){
+            throw new RuntimeException("Security Context에 인증 정보가 없습니다.");
+        }
+
+        return Long.parseLong(authentication.getName());
+
+    }
+
+}

--- a/src/main/java/com/fastcampus/toyproject/config/security/config/CorsConfig.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/config/CorsConfig.java
@@ -1,0 +1,26 @@
+package com.fastcampus.toyproject.config.security.config;
+
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter(){
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        source.registerCorsConfiguration("/api/**", config);
+        return new CorsFilter(source);
+    }
+
+}

--- a/src/main/java/com/fastcampus/toyproject/config/security/config/JwtSecurityConfig.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/config/JwtSecurityConfig.java
@@ -1,0 +1,21 @@
+package com.fastcampus.toyproject.config.security.config;
+
+import com.fastcampus.toyproject.config.security.filter.JwtFilter;
+import com.fastcampus.toyproject.config.security.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        JwtFilter customFilter = new JwtFilter(tokenProvider);
+        http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/config/security/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/config/SecurityConfig.java
@@ -1,0 +1,74 @@
+package com.fastcampus.toyproject.config.security.config;
+
+import com.fastcampus.toyproject.config.security.jwt.JwtAccessDeniedHanlder;
+import com.fastcampus.toyproject.config.security.jwt.JwtAuthenticationEntryPoint;
+import com.fastcampus.toyproject.config.security.jwt.TokenProvider;
+import com.fastcampus.toyproject.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final TokenProvider tokenProvider;
+    private final CorsFilter corsFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHanlder jwtAccessDeniedHanlder;
+
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http.csrf().disable()
+            .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling()
+            .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+            .accessDeniedHandler(jwtAccessDeniedHanlder)
+            .and()
+
+            .headers()
+            .frameOptions()
+            .sameOrigin()
+            .and()
+
+            .sessionManagement()
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+
+            .authorizeHttpRequests()
+            .requestMatchers(
+                new AntPathRequestMatcher("/auth/**")
+            ).permitAll()
+            .anyRequest().authenticated()
+            .and()
+
+            .apply(new JwtSecurityConfig(tokenProvider));
+
+        return http.build();
+    }
+
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+
+
+
+}

--- a/src/main/java/com/fastcampus/toyproject/config/security/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.fastcampus.toyproject.config.security.config;
 import com.fastcampus.toyproject.config.security.jwt.JwtAccessDeniedHanlder;
 import com.fastcampus.toyproject.config.security.jwt.JwtAuthenticationEntryPoint;
 import com.fastcampus.toyproject.config.security.jwt.TokenProvider;
+import com.fastcampus.toyproject.domain.user.entity.Authority;
 import com.fastcampus.toyproject.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/fastcampus/toyproject/config/security/filter/JwtFilter.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/filter/JwtFilter.java
@@ -1,0 +1,47 @@
+package com.fastcampus.toyproject.config.security.filter;
+
+import com.fastcampus.toyproject.config.security.jwt.TokenProvider;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        String jwt = resolveToken(request);
+
+        if(StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)){
+            Authentication authentication = tokenProvider.getAuthentication(jwt);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)){
+            return bearerToken.split(" ")[1].trim();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/config/security/jwt/JwtAccessDeniedHanlder.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/jwt/JwtAccessDeniedHanlder.java
@@ -1,0 +1,24 @@
+package com.fastcampus.toyproject.config.security.jwt;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAccessDeniedHanlder implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/config/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package com.fastcampus.toyproject.config.security.jwt;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException authException
+    ) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/config/security/jwt/TokenProvider.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/jwt/TokenProvider.java
@@ -1,0 +1,123 @@
+package com.fastcampus.toyproject.config.security.jwt;
+
+import com.fastcampus.toyproject.domain.user.dto.TokenDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class TokenProvider {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String BEARER_TYPE = "Bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+
+    private final Key key;
+
+    public TokenProvider(@Value("${jwt.secret}") String secretyKey) {
+        byte[] keyBytes = Decoders.BASE64URL.decode(secretyKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public TokenDto generateTokenDto(Authentication authentication){
+
+        String authrities = authentication.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+
+        String accessToken = Jwts.builder()
+            .setSubject(authentication.getName())
+            .claim(AUTHORITIES_KEY, authrities)
+            .setExpiration(accessTokenExpiresIn)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
+
+        String refreshToken = Jwts.builder()
+            .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
+
+        return TokenDto.builder()
+            .grantType(BEARER_TYPE)
+            .accessToken(accessToken)
+            .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+            .refreshToken(refreshToken)
+            .build();
+
+    }
+
+    public Authentication getAuthentication(String accessToken){
+
+        Claims claims = parseClaims(accessToken);
+
+        if(claims.get(AUTHORITIES_KEY) == null){
+            throw new RuntimeException("권한 정보가 없는 토큰 입니다.");
+        }
+
+        Collection<? extends GrantedAuthority> authorities =
+            Arrays.stream(
+                claims.get(AUTHORITIES_KEY).toString().split(","))
+            .map(SimpleGrantedAuthority::new)
+            .collect(Collectors.toList());
+
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+
+    }
+
+    public boolean validateToken(String token){
+
+        try{
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e){
+            log.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e){
+            log.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e){
+            log.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e){
+            log.info("JWT 토큰이 잘못되었습니다.");
+        }
+
+        return false;
+
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e){
+            return e.getClaims();
+        }
+
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/config/security/jwt/TokenProvider.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/jwt/TokenProvider.java
@@ -1,6 +1,7 @@
 package com.fastcampus.toyproject.config.security.jwt;
 
 import com.fastcampus.toyproject.domain.user.dto.TokenDto;
+import com.fastcampus.toyproject.domain.user.entity.Authority;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -29,7 +30,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class TokenProvider {
 
-    private static final String AUTHORITIES_KEY = "auth";
+    private static final String AUTHORITIES_KEY = "roles";
     private static final String BEARER_TYPE = "Bearer";
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
@@ -54,6 +55,7 @@ public class TokenProvider {
         String accessToken = Jwts.builder()
             .setSubject(authentication.getName())
             .claim(AUTHORITIES_KEY, authrities)
+            .claim("roles", Authority.ROLE_USER.getAuthority())
             .setExpiration(accessTokenExpiresIn)
             .signWith(key, SignatureAlgorithm.HS256)
             .compact();

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/user/{userId}/trip")
+@RequestMapping("/api/trip")
 public class TripController {
 
     private final TripService tripService;

--- a/src/main/java/com/fastcampus/toyproject/domain/user/controller/UserController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/controller/UserController.java
@@ -1,11 +1,17 @@
 package com.fastcampus.toyproject.domain.user.controller;
 
 import com.fastcampus.toyproject.common.dto.ResponseDTO;
+import com.fastcampus.toyproject.domain.user.dto.LoginDto;
+import com.fastcampus.toyproject.domain.user.dto.TokenDto;
+import com.fastcampus.toyproject.domain.user.dto.TokenRequestDto;
 import com.fastcampus.toyproject.domain.user.dto.UserRequestDTO;
 import com.fastcampus.toyproject.domain.user.dto.UserResponseDTO;
 import com.fastcampus.toyproject.domain.user.entity.User;
 import com.fastcampus.toyproject.domain.user.service.UserService;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.catalina.connector.Response;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,17 +19,27 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/user")
+@RequestMapping("/auth")
 public class UserController {
 
     private final UserService userService;
 
-    @PostMapping
-    public ResponseDTO<UserResponseDTO> insert(@RequestBody UserRequestDTO userRequestDTO) {
-        User savedUser = userService.insertUser(userRequestDTO);
-        UserResponseDTO responseData = new UserResponseDTO(savedUser.getUserId(),
-            savedUser.getEmail());
-        return ResponseDTO.ok("회원 등록 성공!", responseData);
+    @PostMapping("/join")
+    public ResponseDTO<UserResponseDTO> insert(
+        @Valid @RequestBody UserRequestDTO userRequestDTO) {
+
+        UserResponseDTO user = userService.insertUser(userRequestDTO);
+        return ResponseDTO.ok("회원 등록 성공!", user);
+    }
+
+    @PostMapping("/login")
+    public ResponseDTO<TokenDto> login(@Valid @RequestBody LoginDto loginDto){
+        return ResponseDTO.ok("로그인 성공", userService.login(loginDto));
+    }
+
+    @PostMapping("/reissue")
+    public ResponseDTO<TokenDto> reissue(@RequestBody TokenRequestDto tokenRequestDto){
+        return ResponseDTO.ok("Refesh 성공", userService.reissue(tokenRequestDto));
     }
 
 

--- a/src/main/java/com/fastcampus/toyproject/domain/user/dto/LoginDto.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/dto/LoginDto.java
@@ -1,0 +1,20 @@
+package com.fastcampus.toyproject.domain.user.dto;
+
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+@Getter
+public class LoginDto {
+
+    @NotNull(message = "이메일을 입력하셔야 합니다.")
+    private String email;
+
+    @NotNull(message = "비밀번호를 입력하셔야 합니다.")
+    private String password;
+
+    public UsernamePasswordAuthenticationToken toAuthentication() {
+        return new UsernamePasswordAuthenticationToken(email, password);
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/user/dto/RefreshToken.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/dto/RefreshToken.java
@@ -1,0 +1,32 @@
+package com.fastcampus.toyproject.domain.user.dto;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class RefreshToken {
+
+    @Id
+    @Column(name = "rt_key")
+    private String key;
+
+    @Column(name = "rt_value")
+    private String value;
+
+    @Builder
+    public RefreshToken(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public RefreshToken updateValue(String token){
+        this.value = token;
+        return this;
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/user/dto/TokenDto.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/dto/TokenDto.java
@@ -1,0 +1,21 @@
+package com.fastcampus.toyproject.domain.user.dto;
+
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class TokenDto {
+
+    private String grantType;
+
+    private String accessToken;
+
+    private Long accessTokenExpiresIn;
+
+    private String refreshToken;
+
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/user/dto/TokenRequestDto.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/dto/TokenRequestDto.java
@@ -1,0 +1,13 @@
+package com.fastcampus.toyproject.domain.user.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class TokenRequestDto {
+
+    private String accessToken;
+    private String refreshToken;
+
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/dto/UserRequestDTO.java
@@ -1,7 +1,11 @@
 package com.fastcampus.toyproject.domain.user.dto;
 
+import com.fastcampus.toyproject.common.BaseTimeEntity;
+import com.fastcampus.toyproject.domain.user.entity.Authority;
+import com.fastcampus.toyproject.domain.user.entity.User;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 public class UserRequestDTO {
@@ -12,4 +16,16 @@ public class UserRequestDTO {
     @NotNull(message = "비밀번호를 입력하셔야 합니다.")
     private String password;
 
+    @NotNull(message = "이름을 입력하셔야 합니다.")
+    private String name;
+
+    public User toUser(PasswordEncoder passwordEncoder) {
+        return User.builder()
+            .email(email)
+            .password(passwordEncoder.encode(password))
+            .name(name)
+            .authority(Authority.ROLE_USER)
+            .baseTimeEntity(new BaseTimeEntity())
+            .build();
+    }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/dto/UserResponseDTO.java
@@ -1,13 +1,26 @@
 package com.fastcampus.toyproject.domain.user.dto;
 
 
+import com.fastcampus.toyproject.domain.user.entity.User;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class UserResponseDTO {
 
     private Long userId;
     private String email;
+    private String name;
+
+    public static UserResponseDTO of(User user) {
+        return UserResponseDTO.builder()
+            .userId(user.getUserId())
+            .email(user.getEmail())
+            .name(user.getName())
+            .build();
+
+    }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/user/entity/Authority.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/entity/Authority.java
@@ -1,0 +1,6 @@
+package com.fastcampus.toyproject.domain.user.entity;
+
+public enum Authority {
+
+    ROLE_USER;
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/user/entity/Authority.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/entity/Authority.java
@@ -1,6 +1,19 @@
 package com.fastcampus.toyproject.domain.user.entity;
 
-public enum Authority {
+import org.springframework.security.core.GrantedAuthority;
 
-    ROLE_USER;
+public enum Authority implements GrantedAuthority {
+
+    ROLE_USER("USER");
+
+    private String authority;
+
+    Authority(String authority) {
+        this.authority = authority;
+    }
+
+    @Override
+    public String getAuthority() {
+        return this.authority;
+    }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/user/entity/User.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/entity/User.java
@@ -4,10 +4,14 @@ import com.fastcampus.toyproject.common.BaseTimeEntity;
 import com.fastcampus.toyproject.domain.liketrip.entity.LikeTrip;
 import com.fastcampus.toyproject.domain.reply.entity.Reply;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -18,13 +22,16 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class User {
+public class User{
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,14 +39,18 @@ public class User {
     private Long userId;
 
     @Column(nullable = false)
-    @Comment("비밀번호")
-    private String password;
-
-    @Column(nullable = false)
     @Comment("이메일")
     private String email;
 
-    private String authority;
+    @Column(nullable = false)
+    @Comment("비밀번호")
+    private String password;
+
+    @Comment("이름")
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private Authority authority;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<Trip> tripList;

--- a/src/main/java/com/fastcampus/toyproject/domain/user/exception/BadCredentialsException.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/exception/BadCredentialsException.java
@@ -1,0 +1,9 @@
+package com.fastcampus.toyproject.domain.user.exception;
+
+public class BadCredentialsException extends RuntimeException{
+
+
+    public BadCredentialsException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/user/exception/ExistEmailExcpetion.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/exception/ExistEmailExcpetion.java
@@ -1,0 +1,8 @@
+package com.fastcampus.toyproject.domain.user.exception;
+
+public class ExistEmailExcpetion extends RuntimeException{
+
+    public ExistEmailExcpetion(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/user/exception/UserEmailNotFoundException.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/exception/UserEmailNotFoundException.java
@@ -1,0 +1,7 @@
+package com.fastcampus.toyproject.domain.user.exception;
+
+public class UserEmailNotFoundException extends RuntimeException{
+
+
+
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.fastcampus.toyproject.domain.user.repository;
+
+import com.fastcampus.toyproject.domain.user.dto.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByKey(String key);
+
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/repository/UserRepository.java
@@ -1,10 +1,15 @@
 package com.fastcampus.toyproject.domain.user.repository;
 
 import com.fastcampus.toyproject.domain.user.entity.User;
+import java.util.Optional;
+import javax.swing.text.html.Option;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/user/service/UserService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/service/UserService.java
@@ -1,34 +1,95 @@
 package com.fastcampus.toyproject.domain.user.service;
 
 import com.fastcampus.toyproject.common.BaseTimeEntity;
+import com.fastcampus.toyproject.config.security.jwt.TokenProvider;
+import com.fastcampus.toyproject.domain.user.dto.LoginDto;
+import com.fastcampus.toyproject.domain.user.dto.RefreshToken;
+import com.fastcampus.toyproject.domain.user.dto.TokenDto;
+import com.fastcampus.toyproject.domain.user.dto.TokenRequestDto;
 import com.fastcampus.toyproject.domain.user.dto.UserRequestDTO;
+import com.fastcampus.toyproject.domain.user.dto.UserResponseDTO;
+import com.fastcampus.toyproject.domain.user.entity.Authority;
 import com.fastcampus.toyproject.domain.user.entity.User;
+import com.fastcampus.toyproject.domain.user.exception.ExistEmailExcpetion;
+import com.fastcampus.toyproject.domain.user.repository.RefreshTokenRepository;
 import com.fastcampus.toyproject.domain.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
 
-    public User insertUser(UserRequestDTO userRequestDTO) {
-        User user = User.builder()
-                .email(userRequestDTO.getEmail())
-                .password(userRequestDTO.getPassword())
-                .authority("ROLE_USER")
-                .baseTimeEntity(new BaseTimeEntity())
-                .build();
-        User saveUser = userRepository.save(user);
-        if (saveUser != null) {
-            return saveUser;
+    @Transactional
+    public UserResponseDTO insertUser(UserRequestDTO userRequestDTO) {
+
+        if(userRepository.existsByEmail(userRequestDTO.getEmail())){
+            throw new ExistEmailExcpetion("존재하는 사용자 이메일");
         }
-        return null; //이거 수정 예정!!
+
+        User user = userRequestDTO.toUser(passwordEncoder);
+
+        return UserResponseDTO.of(userRepository.save(user));
     }
 
     public User getUser(Long userId) {
         return userRepository.getReferenceById(userId);
     }
 
+    public TokenDto login(LoginDto loginDto) {
+
+        UsernamePasswordAuthenticationToken authentication =
+            loginDto.toAuthentication();
+
+        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+
+        RefreshToken refreshToken = RefreshToken.builder()
+            .key(authentication.getName())
+            .value(tokenDto.getRefreshToken())
+            .build();
+
+        refreshTokenRepository.save(refreshToken);
+
+        return tokenDto;
+    }
+
+    public TokenDto reissue(TokenRequestDto tokenRequestDto) {
+
+        if(!tokenProvider.validateToken(tokenRequestDto.getRefreshToken())){
+            throw new RuntimeException("Refresh Token이 유효하지 않습니다.");
+        }
+
+        Authentication authentication = tokenProvider.getAuthentication(tokenRequestDto.getAccessToken());
+
+        RefreshToken refreshToken = refreshTokenRepository.findByKey(authentication.getName())
+            .orElseThrow(() -> new RuntimeException("로그아웃 된 사용자 입니다."));
+
+        if(!refreshToken.getValue().equals(tokenRequestDto.getRefreshToken())){
+            throw new RuntimeException("토큰의 유저정보가 일치하지 않습니다.");
+        }
+
+        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+
+        RefreshToken newRefreshToken = refreshToken.updateValue(tokenDto.getRefreshToken());
+        refreshTokenRepository.save(newRefreshToken);
+
+        return tokenDto;
+
+    }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/user/service/UserService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/service/UserService.java
@@ -11,6 +11,7 @@ import com.fastcampus.toyproject.domain.user.dto.UserResponseDTO;
 import com.fastcampus.toyproject.domain.user.entity.Authority;
 import com.fastcampus.toyproject.domain.user.entity.User;
 import com.fastcampus.toyproject.domain.user.exception.ExistEmailExcpetion;
+import com.fastcampus.toyproject.domain.user.exception.UserEmailNotFoundException;
 import com.fastcampus.toyproject.domain.user.repository.RefreshTokenRepository;
 import com.fastcampus.toyproject.domain.user.repository.UserRepository;
 import java.time.LocalDateTime;
@@ -53,6 +54,13 @@ public class UserService {
     }
 
     public TokenDto login(LoginDto loginDto) {
+
+        User user = userRepository.findByEmail(loginDto.getEmail())
+            .orElseThrow(() -> new RuntimeException("사용자가 없습니다."));
+
+//        if(passwordEncoder.matches(loginDto.getPassword(), user.getPassword())){
+//            throw new RuntimeException("비밀번호가 틀립니다.");
+//        }
 
         UsernamePasswordAuthenticationToken authentication =
             loginDto.toAuthentication();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     database: mysql
     show-sql: true
     properties:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     database: mysql
     show-sql: true
     properties:
@@ -21,10 +21,11 @@ spring:
     base-url: https://maps.googleapis.com/maps/api/geocode/json?address=
     key: API_KEY
 
+jwt:
+  secret: kCXoHrvI0tyx66krErbdTIjUrylFcJQLq4IFSy0NYdNVWWSggYFRWOvuSNsswJtp
+
 server:
   address: localhost
   #  error:
   #    include-stacktrace: never
   port: 8080
-
-

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -29,7 +29,7 @@
 
   <property name="LOGS" value="./logs"/>
 
-  <root level="DEBUG">
+  <root level="INFO">
     <appender-ref ref="CONSOLE"/>
     <appender-ref ref="RollingFile"/>
   </root>


### PR DESCRIPTION
## 개요
Spring Security 설정과, JWT생성, 회원가입, 로그인 기능입니다.

## 작업사항
Spring Security를 통해 인증받지 않은 사용자는 특정 URL에 접근 못하도록 설정
로그인 시에 JWT토큰 발행
회원가입시 비밀번호 암호화 저장

security와 jwt는 회원가입, 로그인과 너무 연관이 깊어서 제 담당이 아닌데 일단 제작하였습니다.
현재 아래와 같은 문제점이 있습니다.

### 확인 된 문제점
- 현재 로그인은 비밀번호 비교에 문제가 있어 ID만 검증하는 문제점
- 로그인을 통해 발행받은 JWT 토큰이 헤더가 아닌 http response body에 담겨져 있어, 해당 JWT를 이용한 요청시 postman 에서 요청을 보낼때 매번 토큰을 header에 추가해야 하는 문제점.
- JWT의 refresh token이 있으나 유효하게 사용되지 않고 있는 문제점
- 공통의 DefaultException을 쓰지않고 RuntimeException을 사용하는 점

위 문제점들은 앞으로 수정해 나가도록 하겠습니다.

## 사용방법

- 회원가입
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/40512982/61d90cc1-bdf9-41a1-9b06-e04109cd93a5)

위 스샷 처럼 POST /auth/join 으로 회원가입을 합니다.

- 로그인
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/40512982/5cc8ffc1-686a-4b2a-89d3-1c6736dc4b7a)

POST /auth/login 으로 id, pw를 보내면
response body에 JWT 토큰이 발행 됩니다.


- JWT 토큰 헤더에 담기
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/40512982/4105ab21-6d55-4e03-86c4-4d0fca9a9aee)

위에서 받은 accessToken의 값을 헤더에 문자열로 추가합니다.
key :  Authorization, 
value : Bearer 리턴받은엑세스토큰 (Bearer 뒤에 띄어쓰기 한칸)

- 사용자 정보 가져오기
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/40512982/8148fea2-8ce6-477e-a5ff-78b1ddd69d43)

Controller에서 Authentication 객체를 파라미터로 받으면, JWT가 필터를 지나면서 securityContext 내부에 저장한 값을 가져오게 됩니다.


## 기타
시큐리티 설정과 구현을 위해 제 임의로 바꾼 부분들이 꽤 있을거 같습니다.
추후 회의나 디코를 통해 의견을 나눠보면 좋을 것 같습니다.
