### PR TITLE
[feat & fix & test] 여정-여행 수정 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/ToyprojectApplication.java
+++ b/src/main/java/com/fastcampus/toyproject/ToyprojectApplication.java
@@ -2,6 +2,8 @@ package com.fastcampus.toyproject;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
 
 @SpringBootApplication
 public class ToyprojectApplication {

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("api/user/{userId}/trip-itineraries")
+@RequestMapping("api/trip-itineraries")
 public class ItineraryController {
 
     private final ItineraryService itineraryService;

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
@@ -25,7 +25,7 @@ public class ItineraryRequest {
     private ItineraryType type;
 
     @NotNull(message = "여정 이름을 입력하세요. ")
-    private String item;
+    private String name;
 
     @NotNull(message = "출발 날짜를 입력하세요.")
     private LocalDateTime startDate;
@@ -39,15 +39,5 @@ public class ItineraryRequest {
 
     private String departurePlace;
     private String arrivalPlace;
-
-    public String getMovementName() {
-        if (this.departurePlace == null) {
-            throw new ItineraryException(EMPTY_DEPARTURE_PLACE);
-        }
-        if (this.arrivalPlace == null) {
-            throw new ItineraryException(EMPTY_ARRIVAL_PLACE);
-        }
-        return this.departurePlace + " -> " + this.arrivalPlace;
-    }
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
@@ -37,7 +37,6 @@ public class MovementResponse extends ItineraryResponse {
             .arrivalDate(entity.getArrivalDate())
             .departurePlace(entity.getDeparturePlace())
             .arrivalPlace(entity.getArrivalPlace())
-            .transportation(entity.getTransportation())
             .timeDifference(
                 DateUtil.getTimeBetweenDate(entity.getDepartureDate(), entity.getArrivalDate()))
             .departureLocation(locationUtil.findLocation(entity.getDeparturePlace()))

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
@@ -21,7 +21,6 @@ public class MovementResponse extends ItineraryResponse {
     private LocalDateTime arrivalDate;
     private String departurePlace;
     private String arrivalPlace;
-    private String transportation;
     private String timeDifference;
     private String departureLocation;
     private String arrivalLocation;

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/ItineraryFactory.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/ItineraryFactory.java
@@ -1,7 +1,13 @@
 package com.fastcampus.toyproject.domain.itinerary.entity;
 
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.EMPTY_ARRIVAL_PLACE;
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.EMPTY_DEPARTURE_PLACE;
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.EMPTY_TRANSPORTATION;
+
 import com.fastcampus.toyproject.common.BaseTimeEntity;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequest;
+import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
+import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode;
 import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import java.util.HashMap;
@@ -17,25 +23,26 @@ public class ItineraryFactory {
         ItineraryRequest, Itinerary>> map = new HashMap<>();
 
     static {
-        map.put(ItineraryType.MOVEMENT, (trip, ir) ->
-            Movement.builder()
-                .trip(trip)
-                .itineraryName(ir.getMovementName())
-                .itineraryOrder(ir.getOrder())
-                .itineraryType(ir.getType())
-                .departureDate(ir.getStartDate())
-                .arrivalDate(ir.getEndDate())
-                .departurePlace(ir.getDeparturePlace())
-                .arrivalPlace(ir.getArrivalPlace())
-                .transportation(ir.getItem())
-                .baseTimeEntity(new BaseTimeEntity())
-                .build()
+        map.put(ItineraryType.MOVEMENT, (trip, ir) -> {
+            isValidMovement(ir);
+            return Movement.builder()
+                    .trip(trip)
+                    .itineraryName(ir.getName())
+                    .itineraryOrder(ir.getOrder())
+                    .itineraryType(ir.getType())
+                    .departureDate(ir.getStartDate())
+                    .arrivalDate(ir.getEndDate())
+                    .departurePlace(ir.getDeparturePlace())
+                    .arrivalPlace(ir.getArrivalPlace())
+                    .baseTimeEntity(new BaseTimeEntity())
+                    .build();
+            }
         );
 
         map.put(ItineraryType.LODGEMENT, (trip, ir) ->
             Lodgement.builder()
                 .trip(trip)
-                .itineraryName(ir.getItem())
+                .itineraryName(ir.getName())
                 .itineraryOrder(ir.getOrder())
                 .itineraryType(ir.getType())
                 .checkIn(ir.getStartDate())
@@ -47,7 +54,7 @@ public class ItineraryFactory {
         map.put(ItineraryType.STAY, (trip, ir) ->
             Stay.builder()
                 .trip(trip)
-                .itineraryName(ir.getItem())
+                .itineraryName(ir.getName())
                 .itineraryOrder(ir.getOrder())
                 .itineraryType(ir.getType())
                 .departureDate(ir.getStartDate())
@@ -55,6 +62,15 @@ public class ItineraryFactory {
                 .baseTimeEntity(new BaseTimeEntity())
                 .build()
         );
+    }
+
+    private static void isValidMovement(ItineraryRequest ir) {
+        if (ir.getArrivalPlace() == null) {
+            throw new ItineraryException(EMPTY_ARRIVAL_PLACE);
+        }
+        if (ir.getDeparturePlace() == null) {
+            throw new ItineraryException(EMPTY_DEPARTURE_PLACE);
+        }
     }
 
     public static Itinerary getItineraryEntity(Trip trip, ItineraryRequest ir) {

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
@@ -35,7 +35,7 @@ public class Lodgement extends Itinerary {
     private Double lng;
 
     public void updateLodgement(ItineraryUpdateRequest req) {
-        super.updateItineraryName(req.getItem());
+        super.updateItineraryName(req.getName());
         super.updateItineraryOrder(req.getOrder());
         this.checkIn = req.getStartDate();
         this.checkOut = req.getEndDate();

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
@@ -34,10 +34,6 @@ public class Movement extends Itinerary {
     @Comment("도착 장소")
     private String arrivalPlace;
 
-    @Column(nullable = false)
-    @Comment("운송수단이름")
-    private String transportation;
-
     @Comment("출발지 위치 정보")
     private String departurePlaceInfo;
 
@@ -57,9 +53,8 @@ public class Movement extends Itinerary {
     private Double arrivalLng;
 
     public void updateMovement(ItineraryUpdateRequest req) {
-        super.updateItineraryName(req.getMovementName());
+        super.updateItineraryName(req.getName());
         super.updateItineraryOrder(req.getOrder());
-        this.transportation = req.getItem();
         this.departureDate = req.getStartDate();
         this.departurePlace = req.getDeparturePlace();
         this.arrivalDate = req.getEndDate();

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Stay.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Stay.java
@@ -35,7 +35,7 @@ public class Stay extends Itinerary {
     private Double lng;
 
     public void updateStay(ItineraryUpdateRequest req) {
-        super.updateItineraryName(req.getItem());
+        super.updateItineraryName(req.getName());
         super.updateItineraryOrder(req.getOrder());
         this.departureDate = req.getStartDate();
         this.arrivalDate = req.getEndDate();

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryExceptionCode.java
@@ -1,12 +1,14 @@
 package com.fastcampus.toyproject.domain.itinerary.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpServerErrorException.InternalServerError;
 
 @AllArgsConstructor
 @Getter
@@ -18,8 +20,11 @@ public enum ItineraryExceptionCode implements ExceptionCode {
     EMPTY_ITINERARY(BAD_REQUEST, "EMPTY_ITINERARY","수정 할 여정 정보가 없습니다."),
     EMPTY_DEPARTURE_PLACE(BAD_REQUEST, "EMPTY_DEPARTURE_PLACE","출발지를 입력하지 않았습니다."),
     EMPTY_ARRIVAL_PLACE(BAD_REQUEST, "EMPTY_ARRIVAL_PLACE","도착지를 입력하지 않았습니다."),
+    EMPTY_TRANSPORTATION(BAD_REQUEST, "EMPTY_TRANSPORTATION","교통수단을 입력하지 않았습니다."),
     ILLEGAL_ITINERARY_TYPE(BAD_REQUEST, "ILLEGAL_ITINERARY_TYPE","잘 못 된 여정 타입입니다."),
-    ITINERARY_ALREADY_DELETED(BAD_REQUEST, "ITINERARY_ALREADY_DELETED","이미 삭제된 여정입니다.");
+    ITINERARY_ALREADY_DELETED(BAD_REQUEST, "ITINERARY_ALREADY_DELETED","이미 삭제된 여정입니다."),
+    ITINERARY_SAVE_FAILED(INTERNAL_SERVER_ERROR, "ITINERARY_SAVE_FAILED", "여정 저장에 실패하였습니다.")
+    ;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -90,17 +90,18 @@ public class ItineraryService {
 
         validateItineraryRequestOrder(itineraryRequests, trip);
 
+        List<Itinerary> itineraryList = new ArrayList<>();
         for (ItineraryRequest ir : itineraryRequests) {
-
-            Itinerary itinerary = ItineraryFactory.getItineraryEntity(trip, ir);
-
-            Itinerary savedItinerary = itineraryRepository.save(itinerary);
-
-            itineraryResponseList.add(
-                ItineraryResponseFactory.getItineraryResponse(savedItinerary)
-            );
+            itineraryList.add(ItineraryFactory.getItineraryEntity(trip, ir));
         }
-
+        List<Itinerary> saveItineraryList = itineraryRepository.saveAll(itineraryList);
+        if (saveItineraryList != null) { //요부분
+            for (Itinerary it : saveItineraryList) {
+                itineraryResponseList.add(
+                        ItineraryResponseFactory.getItineraryResponse(it)
+                );
+            }
+        }
         ItineraryOrderUtil.sortItineraryResponseListByOrder(itineraryResponseList);
         return itineraryResponseList;
     }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -95,7 +95,7 @@ public class ItineraryService {
             itineraryList.add(ItineraryFactory.getItineraryEntity(trip, ir));
         }
         List<Itinerary> saveItineraryList = itineraryRepository.saveAll(itineraryList);
-        if (saveItineraryList != null) { //요부분
+        if (saveItineraryList != null) {
             for (Itinerary it : saveItineraryList) {
                 itineraryResponseList.add(
                         ItineraryResponseFactory.getItineraryResponse(it)

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -6,6 +6,7 @@ import com.fastcampus.toyproject.domain.trip.dto.TripDetailResponse;
 import com.fastcampus.toyproject.domain.trip.dto.TripRequest;
 import com.fastcampus.toyproject.domain.trip.dto.TripResponse;
 import com.fastcampus.toyproject.domain.trip.service.TripService;
+import com.fastcampus.toyproject.domain.user.entity.User;
 import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/trip")
+@Slf4j
 public class TripController {
 
     private final TripService tripService;
@@ -72,15 +74,18 @@ public class TripController {
 
     @PostMapping()
     public ResponseDTO<TripResponse> insertTrip(
-        @PathVariable final Long userId,
+        Authentication authentication,
         @Valid @RequestBody final TripRequest tripRequest
     ) {
         DateUtil.isStartDateEarlierThanEndDate(
             tripRequest.getStartDate(),
             tripRequest.getEndDate()
         );
+
+        //User user = (User) authentication.getPrincipal();
+        //log.info("TripController:: user name : {} ", user.getName());
         return ResponseDTO.ok("여행 삽입 완료",
-            tripService.insertTrip(userId, tripRequest)
+            tripService.insertTrip(1L, tripRequest)
         );
     }
 

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
@@ -87,6 +87,9 @@ public class Trip {
 
     public void delete() {
         baseTimeEntity.delete(LocalDateTime.now());
+        for (Itinerary it : this.itineraryList) {
+            it.delete();
+        }
     }
 
     public void updateFromDTO(TripRequest tripDTO) {

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripExceptionCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum TripExceptionCode implements ExceptionCode {
-    NO_SUCH_TRIP(UNPROCESSABLE_ENTITY, "NO_SUCH_TRIP", "해당하는 Trip이 없습니다."),
+    NO_SUCH_TRIP(UNPROCESSABLE_ENTITY, "NO_SUCH_TRIP", "해당하는 여행 정보가 없습니다."),
+    TRIP_ALREADY_DELETED(UNPROCESSABLE_ENTITY, "TRIP_ALREADY_DELETED", "이미 삭제된 여행 정보입니다."),
     NOT_MATCH_BETWEEN_USER_AND_TRIP(UNPROCESSABLE_ENTITY, "NOT_MATCH_BETWEEN_USER_AND_TRIP", "유저의 여행 정보가 일치하지 않습니다.")
     ;
 

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
@@ -30,10 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TripService {
 
     private final TripRepository tripRepository;
-    private final UserRepository userRepository;
-    private final ItineraryService itineraryService;
     private final UserService userService;
-
 
     /**
      * trip 아이디를 통한 trip 객체 반환하는 메소드
@@ -58,19 +55,19 @@ public class TripService {
 
         return trip;
     }
-
-    /**
-     * trip 객체로 연관된 itinerary들의 이름만 반환하는 메소드
-     *
-     * @param trip
-     * @return string
-     */
-    public String getItineraryNamesByTrip(Trip trip) {
-        return itineraryService.getItineraryResponseListByTrip(trip)
-            .stream()
-            .map(it -> it.getItineraryName())
-            .collect(Collectors.joining(", "));
-    }
+//
+//    /**
+//     * trip 객체로 연관된 itinerary들의 이름만 반환하는 메소드
+//     *
+//     * @param trip
+//     * @return string
+//     */
+//    public String getItineraryNamesByTrip(Trip trip) {
+//        return itineraryService.getItineraryResponseListByTrip(trip)
+//            .stream()
+//            .map(it -> it.getItineraryName())
+//            .collect(Collectors.joining(", "));
+//    }
 
     /**
      * 삭제 되지 않은 trip 전부를 반환하는 메소드
@@ -152,7 +149,6 @@ public class TripService {
     public TripResponse deleteTrip(Long tripId) {
         Trip trip = getTripByTripId(tripId);
         trip.delete();
-        itineraryService.deleteAllItineraryByTrip(trip);
         return TripResponse.fromEntity(tripRepository.save(trip));
     }
 

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
@@ -3,6 +3,7 @@ package com.fastcampus.toyproject.domain.trip.service;
 
 import static com.fastcampus.toyproject.domain.trip.exception.TripExceptionCode.NOT_MATCH_BETWEEN_USER_AND_TRIP;
 import static com.fastcampus.toyproject.domain.trip.exception.TripExceptionCode.NO_SUCH_TRIP;
+import static com.fastcampus.toyproject.domain.trip.exception.TripExceptionCode.TRIP_ALREADY_DELETED;
 
 import com.fastcampus.toyproject.common.BaseTimeEntity;
 import com.fastcampus.toyproject.common.exception.DefaultException;
@@ -93,7 +94,11 @@ public class TripService {
      */
     @Transactional(readOnly = true)
     public TripDetailResponse getTripDetail(Long tripId) {
-        return TripDetailResponse.fromEntity(getTripByTripId(tripId));
+        Trip trip = getTripByTripId(tripId);
+        if (trip.getBaseTimeEntity().getDeletedAt() != null) {
+            throw new TripException(TRIP_ALREADY_DELETED);
+        }
+        return TripDetailResponse.fromEntity(trip);
     }
 
     /**

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryControllerTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryControllerTest.java
@@ -49,7 +49,7 @@ public class ItineraryControllerTest {
         reqList = List.of(ItineraryUpdateRequest.builder()
             .itineraryId(2L)
             .type(ItineraryType.MOVEMENT)
-            .item("로켓")
+            .name("로켓")
             .startDate(LocalDateTime.now())
             .endDate(LocalDateTime.now())
             .order(3)

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryServiceTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryServiceTest.java
@@ -2,12 +2,15 @@ package com.fastcampus.toyproject.domain.itinerary.service;
 
 import static org.mockito.BDDMockito.given;
 
+import com.fastcampus.toyproject.common.exception.DefaultException;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequest;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
 import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
 import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode;
 import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import com.fastcampus.toyproject.domain.trip.exception.TripException;
+import com.fastcampus.toyproject.domain.trip.exception.TripExceptionCode;
 import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
 import com.fastcampus.toyproject.domain.user.dto.UserRequestDTO;
 import com.fastcampus.toyproject.domain.user.entity.User;
@@ -25,11 +28,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@ExtendWith(MockitoExtension.class)
 @SpringBootTest
 class ItineraryServiceTest {
-    @Mock
-    private UserRepository userRepository;
 
     @Autowired
     private TripRepository tripRepository;
@@ -56,6 +56,17 @@ class ItineraryServiceTest {
 
         for (ItineraryResponse ir : itineraryResponseList) {
             System.out.println(ir.getItineraryType() + ": " + ir.getItineraryName() + " " + ir.getItineraryOrder());
+        }
+    }
+
+    @Test
+    void 여정리스트_삽입_실패_tripId_없는경우() {
+        try {
+            List<ItineraryResponse> itineraryResponseList = itineraryService.insertItineraries(
+                    99L, itineraryRequestList
+            );
+        } catch (TripException e) {
+            Assertions.assertEquals(e.getErrorCode(), TripExceptionCode.NO_SUCH_TRIP);
         }
     }
 

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryServiceTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryServiceTest.java
@@ -1,0 +1,116 @@
+package com.fastcampus.toyproject.domain.itinerary.service;
+
+import static org.mockito.BDDMockito.given;
+
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequest;
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
+import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
+import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode;
+import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
+import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
+import com.fastcampus.toyproject.domain.user.dto.UserRequestDTO;
+import com.fastcampus.toyproject.domain.user.entity.User;
+import com.fastcampus.toyproject.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+class ItineraryServiceTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @Autowired
+    private TripRepository tripRepository;
+
+    @Autowired
+    private ItineraryService itineraryService;
+
+    LocalDateTime now = LocalDateTime.now();
+
+    @BeforeEach
+    void setUp() {
+        itineraryRequestList.add(ir1);
+        itineraryRequestList.add(ir2);
+        itineraryRequestList.add(ir3);
+    }
+
+    @Test
+    void 여정리스트_삽입_성공() {
+        Trip trip1 = tripRepository.save(trip);
+
+        List<ItineraryResponse> itineraryResponseList = itineraryService.insertItineraries(
+                trip1.getTripId(), itineraryRequestList
+        );
+
+        for (ItineraryResponse ir : itineraryResponseList) {
+            System.out.println(ir.getItineraryType() + ": " + ir.getItineraryName() + " " + ir.getItineraryOrder());
+        }
+    }
+
+    @Test
+    void 여정리스트_삽입_실패_순서중복() {
+        ItineraryRequest ir4 = ItineraryRequest.builder()
+                .name("도톤보리").type(ItineraryType.STAY)
+                .startDate(now).endDate(now).order(3) //ir3과 중복.
+                .build();
+        itineraryRequestList.add(ir4);
+
+        Trip trip1 = tripRepository.save(trip);
+
+        try {
+            List<ItineraryResponse> itineraryResponseList = itineraryService.insertItineraries(
+                    trip1.getTripId(), itineraryRequestList
+            );
+        } catch (ItineraryException e) {
+            Assertions.assertEquals(e.getErrorCode(), ItineraryExceptionCode.DUPLICATE_ITINERARY_ORDER);
+        }
+    }
+
+    User user = User.builder()
+            .email("test@mail.com")
+            .password("1234")
+            .build()
+            ;
+    Trip trip = Trip.builder()
+            .tripName("일본여행")
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now())
+            .build();
+
+    List<ItineraryRequest> itineraryRequestList = new ArrayList<>();
+    ItineraryRequest ir1 = ItineraryRequest.builder()
+            .name("비행기")
+            .type(ItineraryType.MOVEMENT)
+            .startDate(now).endDate(now)
+            .departurePlace("인천 공항").arrivalPlace("도쿄 공항")
+            .order(1)
+            .build();
+
+    ItineraryRequest ir2 = ItineraryRequest.builder()
+            .name("도쿄 디즈니 월드")
+            .type(ItineraryType.STAY)
+            .startDate(now).endDate(now)
+            .order(2)
+            .build();
+
+    ItineraryRequest ir3 = ItineraryRequest.builder()
+            .name("신주쿠 워싱턴 호텔")
+            .type(ItineraryType.LODGEMENT)
+            .startDate(now).endDate(now)
+            .order(3)
+            .build();
+
+
+}

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryServiceTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryServiceTest.java
@@ -1,8 +1,5 @@
 package com.fastcampus.toyproject.domain.itinerary.service;
 
-import static org.mockito.BDDMockito.given;
-
-import com.fastcampus.toyproject.common.exception.DefaultException;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequest;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
 import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
@@ -12,19 +9,13 @@ import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fastcampus.toyproject.domain.trip.exception.TripException;
 import com.fastcampus.toyproject.domain.trip.exception.TripExceptionCode;
 import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
-import com.fastcampus.toyproject.domain.user.dto.UserRequestDTO;
 import com.fastcampus.toyproject.domain.user.entity.User;
-import com.fastcampus.toyproject.domain.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -46,48 +37,48 @@ class ItineraryServiceTest {
         itineraryRequestList.add(ir3);
     }
 
-    @Test
-    void 여정리스트_삽입_성공() {
-        Trip trip1 = tripRepository.save(trip);
-
-        List<ItineraryResponse> itineraryResponseList = itineraryService.insertItineraries(
-                trip1.getTripId(), itineraryRequestList
-        );
-
-        for (ItineraryResponse ir : itineraryResponseList) {
-            System.out.println(ir.getItineraryType() + ": " + ir.getItineraryName() + " " + ir.getItineraryOrder());
-        }
-    }
-
-    @Test
-    void 여정리스트_삽입_실패_tripId_없는경우() {
-        try {
-            List<ItineraryResponse> itineraryResponseList = itineraryService.insertItineraries(
-                    99L, itineraryRequestList
-            );
-        } catch (TripException e) {
-            Assertions.assertEquals(e.getErrorCode(), TripExceptionCode.NO_SUCH_TRIP);
-        }
-    }
-
-    @Test
-    void 여정리스트_삽입_실패_순서중복() {
-        ItineraryRequest ir4 = ItineraryRequest.builder()
-                .name("도톤보리").type(ItineraryType.STAY)
-                .startDate(now).endDate(now).order(3) //ir3과 중복.
-                .build();
-        itineraryRequestList.add(ir4);
-
-        Trip trip1 = tripRepository.save(trip);
-
-        try {
-            List<ItineraryResponse> itineraryResponseList = itineraryService.insertItineraries(
-                    trip1.getTripId(), itineraryRequestList
-            );
-        } catch (ItineraryException e) {
-            Assertions.assertEquals(e.getErrorCode(), ItineraryExceptionCode.DUPLICATE_ITINERARY_ORDER);
-        }
-    }
+//    @Test
+//    void 여정리스트_삽입_성공() {
+//        Trip trip1 = tripRepository.save(trip);
+//
+//        List<ItineraryResponse> itineraryResponseList = itineraryService.insertItineraries(
+//                trip1.getTripId(), itineraryRequestList
+//        );
+//
+//        for (ItineraryResponse ir : itineraryResponseList) {
+//            System.out.println(ir.getItineraryType() + ": " + ir.getItineraryName() + " " + ir.getItineraryOrder());
+//        }
+//    }
+//
+//    @Test
+//    void 여정리스트_삽입_실패_tripId_없는경우() {
+//        try {
+//            List<ItineraryResponse> itineraryResponseList = itineraryService.insertItineraries(
+//                    99L, itineraryRequestList
+//            );
+//        } catch (TripException e) {
+//            Assertions.assertEquals(e.getErrorCode(), TripExceptionCode.NO_SUCH_TRIP);
+//        }
+//    }
+//
+//    @Test
+//    void 여정리스트_삽입_실패_순서중복() {
+//        ItineraryRequest ir4 = ItineraryRequest.builder()
+//                .name("도톤보리").type(ItineraryType.STAY)
+//                .startDate(now).endDate(now).order(3) //ir3과 중복.
+//                .build();
+//        itineraryRequestList.add(ir4);
+//
+//        Trip trip1 = tripRepository.save(trip);
+//
+//        try {
+//            List<ItineraryResponse> itineraryResponseList = itineraryService.insertItineraries(
+//                    trip1.getTripId(), itineraryRequestList
+//            );
+//        } catch (ItineraryException e) {
+//            Assertions.assertEquals(e.getErrorCode(), ItineraryExceptionCode.DUPLICATE_ITINERARY_ORDER);
+//        }
+//    }
 
     User user = User.builder()
             .email("test@mail.com")

--- a/src/test/java/com/fastcampus/toyproject/domain/trip/service/TripServiceTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/trip/service/TripServiceTest.java
@@ -40,16 +40,16 @@ class TripServiceTest {
 
     LocalDateTime now = LocalDateTime.now();
 
-    @BeforeEach
-    void setUp() {
+//    @BeforeEach
+//    void setUp() {
 //        User saveUser = userRepository.save(user);
 //        userId = saveUser.getUserId();
-        itineraryRequestList.add(ir1);
-        itineraryRequestList.add(ir2);
-        itineraryRequestList.add(ir3);
-    }
-    @Test
-    void 여행_삭제_성공() {
+//        itineraryRequestList.add(ir1);
+//        itineraryRequestList.add(ir2);
+//        itineraryRequestList.add(ir3);
+//    }
+//    @Test
+//    void 여행_삭제_성공() {
 //        Trip ti = tripRepository.save(trip);
 //        itineraryService.insertItineraries(ti.getTripId(), itineraryRequestList);
 //        tripService.deleteTrip(ti.getTripId());
@@ -58,7 +58,7 @@ class TripServiceTest {
 //        for (Itinerary it : saveTrip.get().getItineraryList()) {
 //            Assertions.assertNotEquals(it.getBaseTimeEntity().getDeletedAt(), null);
 //        }
-    }
+//    }
 
     User user = User.builder()
             .email("test@mail.com")

--- a/src/test/java/com/fastcampus/toyproject/domain/trip/service/TripServiceTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/trip/service/TripServiceTest.java
@@ -50,14 +50,14 @@ class TripServiceTest {
     }
     @Test
     void 여행_삭제_성공() {
-        Trip ti = tripRepository.save(trip);
-        itineraryService.insertItineraries(ti.getTripId(), itineraryRequestList);
-        tripService.deleteTrip(ti.getTripId());
-        Optional<Trip> saveTrip = tripRepository.findById(ti.getTripId());
-        Assertions.assertNotEquals(saveTrip.get().getBaseTimeEntity().getDeletedAt(), null);
-        for (Itinerary it : saveTrip.get().getItineraryList()) {
-            Assertions.assertNotEquals(it.getBaseTimeEntity().getDeletedAt(), null);
-        }
+//        Trip ti = tripRepository.save(trip);
+//        itineraryService.insertItineraries(ti.getTripId(), itineraryRequestList);
+//        tripService.deleteTrip(ti.getTripId());
+//        Optional<Trip> saveTrip = tripRepository.findById(ti.getTripId());
+//        Assertions.assertNotEquals(saveTrip.get().getBaseTimeEntity().getDeletedAt(), null);
+//        for (Itinerary it : saveTrip.get().getItineraryList()) {
+//            Assertions.assertNotEquals(it.getBaseTimeEntity().getDeletedAt(), null);
+//        }
     }
 
 

--- a/src/test/java/com/fastcampus/toyproject/domain/trip/service/TripServiceTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/trip/service/TripServiceTest.java
@@ -1,0 +1,101 @@
+package com.fastcampus.toyproject.domain.trip.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fastcampus.toyproject.common.BaseTimeEntity;
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequest;
+import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
+import com.fastcampus.toyproject.domain.itinerary.service.ItineraryService;
+import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
+import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
+import com.fastcampus.toyproject.domain.user.entity.User;
+import com.fastcampus.toyproject.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TripServiceTest {
+    @Autowired
+    private TripRepository tripRepository;
+
+    @Autowired
+    private ItineraryService itineraryService;
+
+    @Autowired
+    private TripService tripService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    Long userId;
+
+    LocalDateTime now = LocalDateTime.now();
+
+    @BeforeEach
+    void setUp() {
+        User saveUser = userRepository.save(user);
+        userId = saveUser.getUserId();
+        itineraryRequestList.add(ir1);
+        itineraryRequestList.add(ir2);
+        itineraryRequestList.add(ir3);
+    }
+    @Test
+    void 여행_삭제_성공() {
+        Trip ti = tripRepository.save(trip);
+        itineraryService.insertItineraries(ti.getTripId(), itineraryRequestList);
+        tripService.deleteTrip(ti.getTripId());
+        Optional<Trip> saveTrip = tripRepository.findById(ti.getTripId());
+        Assertions.assertNotEquals(saveTrip.get().getBaseTimeEntity().getDeletedAt(), null);
+        for (Itinerary it : saveTrip.get().getItineraryList()) {
+            Assertions.assertNotEquals(it.getBaseTimeEntity().getDeletedAt(), null);
+        }
+    }
+
+
+
+    User user = User.builder()
+            .email("test@mail.com")
+            .password("1234")
+            .build()
+            ;
+    Trip trip = Trip.builder()
+            .tripName("일본여행")
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now())
+            .baseTimeEntity(new BaseTimeEntity())
+            .user(user)
+            .build();
+
+    List<ItineraryRequest> itineraryRequestList = new ArrayList<>();
+    ItineraryRequest ir1 = ItineraryRequest.builder()
+            .name("비행기")
+            .type(ItineraryType.MOVEMENT)
+            .startDate(now).endDate(now)
+            .departurePlace("인천 공항").arrivalPlace("도쿄 공항")
+            .order(1)
+            .build();
+
+    ItineraryRequest ir2 = ItineraryRequest.builder()
+            .name("도쿄 디즈니 월드")
+            .type(ItineraryType.STAY)
+            .startDate(now).endDate(now)
+            .order(2)
+            .build();
+
+    ItineraryRequest ir3 = ItineraryRequest.builder()
+            .name("신주쿠 워싱턴 호텔")
+            .type(ItineraryType.LODGEMENT)
+            .startDate(now).endDate(now)
+            .order(3)
+            .build();
+
+}

--- a/src/test/java/com/fastcampus/toyproject/domain/trip/service/TripServiceTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/trip/service/TripServiceTest.java
@@ -42,8 +42,8 @@ class TripServiceTest {
 
     @BeforeEach
     void setUp() {
-        User saveUser = userRepository.save(user);
-        userId = saveUser.getUserId();
+//        User saveUser = userRepository.save(user);
+//        userId = saveUser.getUserId();
         itineraryRequestList.add(ir1);
         itineraryRequestList.add(ir2);
         itineraryRequestList.add(ir3);
@@ -59,8 +59,6 @@ class TripServiceTest {
 //            Assertions.assertNotEquals(it.getBaseTimeEntity().getDeletedAt(), null);
 //        }
     }
-
-
 
     User user = User.builder()
             .email("test@mail.com")

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itinerary-insert-fail-1.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itinerary-insert-fail-1.http
@@ -1,11 +1,11 @@
 ### 여정 순서 잘못된 버전 (중복된 버전)
-POST http://localhost:8080/api/user/1/trip-itineraries/1
+POST http://localhost:8080/api/user/1/trip-itineraries/2
 Content-Type: application/json
 
 [
   {
     "type": "MOVEMENT",
-    "item": "비행기",
+    "name": "비행기",
     "startDate": "2023-10-22T12:24:10",
     "endDate": "2023-10-22T22:00:10",
     "order": 1,
@@ -14,14 +14,14 @@ Content-Type: application/json
   },
   {
     "type": "STAY",
-    "item": "도쿄 디즈니월드",
+    "name": "도쿄 디즈니월드",
     "startDate": "2023-10-26T12:00:10",
     "endDate": "2023-10-26T20:03:10",
     "order": 2
   },
   {
     "type": "LODGEMENT",
-    "item": "신주쿠 워싱턴 호텔",
+    "name": "신주쿠 워싱턴 호텔",
     "startDate": "2023-10-22T15:00:10",
     "endDate": "2023-10-25T10:00:10",
     "order": 2

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itinerary-insert-fail-2.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itinerary-insert-fail-2.http
@@ -5,7 +5,7 @@ Content-Type: application/json
 [
   {
     "type": "MOVEMENT",
-    "item": "비행기",
+    "name" : "비행기",
     "startDate": "2023-10-29T12:24:10",
     "endDate": "2023-10-22T22:00:10",
     "order": 1,

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itinerary-insert-fail-3.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itinerary-insert-fail-3.http
@@ -1,11 +1,11 @@
 ### 여정 movement시 출발지 or 도착지 입력 안했을 때
-POST http://localhost:8080/api/user/1/trip-itineraries/1
+POST http://localhost:8080/api/user/1/trip-itineraries/2
 Content-Type: application/json
 
 [
   {
     "type": "MOVEMENT",
-    "item": "비행기",
+    "name": "비행기",
     "startDate": "2023-10-22T12:24:10",
     "endDate": "2023-10-22T22:00:10",
     "order": 1,
@@ -13,7 +13,7 @@ Content-Type: application/json
   },
   {
     "type": "MOVEMENT",
-    "item": "비행기",
+    "name": "비행기",
     "startDate": "2023-10-22T12:24:10",
     "endDate": "2023-10-22T22:00:10",
     "order": 2,

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itinerary-insert-success-1.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itinerary-insert-success-1.http
@@ -4,7 +4,7 @@ Content-Type: application/json
 [
   {
     "type": "MOVEMENT",
-    "item": "비행기",
+    "name": "비행기",
     "startDate": "2023-10-22T12:24:10",
     "endDate": "2023-10-22T22:00:10",
     "order": 1,
@@ -13,14 +13,14 @@ Content-Type: application/json
   },
   {
     "type": "STAY",
-    "item": "도쿄 디즈니월드",
+    "name": "도쿄 디즈니월드",
     "startDate": "2023-10-26T12:00:10",
     "endDate": "2023-10-26T20:03:10",
     "order": 2
   },
   {
     "type": "LODGEMENT",
-    "item": "신주쿠 워싱턴 호텔",
+    "name": "신주쿠 워싱턴 호텔",
     "startDate": "2023-10-22T15:00:10",
     "endDate": "2023-10-25T10:00:10",
     "order": 3

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itinerary-insert-success-1.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itinerary-insert-success-1.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/api/user/1/trip-itineraries/1
+POST http://localhost:8080/api/trip-itineraries/1
 Content-Type: application/json
 
 [

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itinerary-insert-success-2.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itinerary-insert-success-2.http
@@ -4,7 +4,7 @@ Content-Type: application/json
 [
   {
     "type": "MOVEMENT",
-    "item": "비행기",
+    "name": "비행기",
     "startDate": "2023-03-02T03:24:10",
     "endDate": "2023-03-03T00:00:10",
     "order": 1,
@@ -13,35 +13,35 @@ Content-Type: application/json
   },
   {
     "type": "STAY",
-    "item": "런던 네셔널 갤러리",
+    "name": "런던 네셔널 갤러리",
     "startDate": "2023-03-03T10:00:10",
     "endDate": "2023-03-03T15:00:10",
     "order": 3
   },
   {
     "type": "LODGEMENT",
-    "item": "런던 브리타니아 인터내셔널 호텔",
+    "name": "런던 브리타니아 인터내셔널 호텔",
     "startDate": "2023-03-02T15:00:10",
     "endDate": "2023-03-05T10:00:10",
     "order": 2
   },
   {
     "type": "STAY",
-    "item": "런던 빅밴",
+    "name": "런던 빅밴",
     "startDate": "2023-03-03T19:00:10",
     "endDate": "2023-03-03T21:00:10",
     "order": 4
   },
   {
     "type": "STAY",
-    "item": "런던 관광명소 투어",
+    "name": "런던 관광명소 투어",
     "startDate": "2023-03-04T10:00:10",
     "endDate": "2023-03-04T19:00:10",
     "order": 5
   },
   {
     "type": "MOVEMENT",
-    "item": "버스, 비행기",
+    "name": "버스, 비행기",
     "startDate": "2023-03-05T10:00:10",
     "endDate": "2023-03-05T15:00:10",
     "order": 6,
@@ -50,35 +50,35 @@ Content-Type: application/json
   },
   {
     "type": "LODGEMENT",
-    "item": "파리 북 어 베드 호스텔",
+    "name": "파리 북 어 베드 호스텔",
     "startDate": "2023-03-05T15:00:10",
     "endDate": "2023-03-08T10:00:10",
     "order": 7
   },
   {
     "type": "STAY",
-    "item": "파리 에펠탑 관광",
+    "name": "파리 에펠탑 관광",
     "startDate": "2023-03-05T18:00:10",
     "endDate": "2023-03-05T21:00:10",
     "order": 8
   },
   {
     "type": "STAY",
-    "item": "파리 루브르 박물관",
+    "name": "파리 루브르 박물관",
     "startDate": "2023-03-06T10:00:10",
     "endDate": "2023-03-06T19:00:10",
     "order": 9
   },
   {
     "type": "STAY",
-    "item": "파리 디즈니 랜드",
+    "name": "파리 디즈니 랜드",
     "startDate": "2023-03-07T10:00:10",
     "endDate": "2023-03-07T21:30:10",
     "order": 10
   },
   {
     "type": "MOVEMENT",
-    "item": "버스",
+    "name": "버스",
     "startDate": "2023-03-08T10:00:10",
     "endDate": "2023-03-08T22:00:10",
     "order": 11,
@@ -87,14 +87,14 @@ Content-Type: application/json
   },
   {
     "type": "LODGEMENT",
-    "item": "인터라켄 유스호스텔",
+    "name": "인터라켄 유스호스텔",
     "startDate": "2023-03-08T15:00:10",
     "endDate": "2023-03-10T10:00:10",
     "order": 12
   },
   {
     "type": "STAY",
-    "item": "인터라켄 융푸라우 투어",
+    "name": "인터라켄 융푸라우 투어",
     "startDate": "2023-03-09T10:00:10",
     "endDate": "2023-03-09T16:30:10",
     "order": 13

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itnerary-insert-success-3.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/insert/itnerary-insert-success-3.http
@@ -4,7 +4,7 @@ Content-Type: application/json
 [
   {
     "type": "MOVEMENT",
-    "item": "버스",
+    "name": "버스",
     "startDate": "2023-10-25T17:03:10",
     "endDate": "2023-10-25T17:03:10",
     "order": 4,
@@ -13,14 +13,14 @@ Content-Type: application/json
   },
   {
     "type": "STAY",
-    "item": "도쿄 타워",
+    "name": "도쿄 타워",
     "startDate": "2023-10-25T17:03:10",
     "endDate": "2023-10-25T17:03:10",
     "order": 3
   },
   {
     "type": "LODGEMENT",
-    "item": "도쿄 온천있는 호텔",
+    "name": "도쿄 온천있는 호텔",
     "startDate": "2023-10-25T17:03:10",
     "endDate": "2023-10-25T17:03:10",
     "order": 5

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/update/itinerary-update-fail-1.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/update/itinerary-update-fail-1.http
@@ -5,7 +5,7 @@ Content-Type: application/json
 {
     "itineraryId": 1,
     "type": "MOVEMENT",
-    "item": "지하철",
+    "name": "지하철",
     "startDate": "2023-10-25T17:03:10",
     "endDate": "2023-10-25T17:03:10",
     "order": 1,

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/update/itinerary-update-fail-2.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/update/itinerary-update-fail-2.http
@@ -5,7 +5,7 @@ Content-Type: application/json
 {
   "itineraryId": 2,
   "type": "MOVEMENT",
-  "item": "지하철",
+  "name": "지하철",
   "startDate": "2023-10-27T17:03:10",
   "endDate": "2023-10-25T17:03:10",
   "order": 1,

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/update/itinerary-update-success-1.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary/update/itinerary-update-success-1.http
@@ -5,7 +5,7 @@ Content-Type: application/json
   {
     "itineraryId": 1,
     "type": "MOVEMENT",
-    "item": "지하철",
+    "name": "지하철",
     "startDate": "2023-10-25T17:03:10",
     "endDate": "2023-10-26T17:03:10",
     "order": 1,
@@ -15,7 +15,7 @@ Content-Type: application/json
   {
     "itineraryId": 2,
     "type": "STAY",
-    "item": "롯데월드",
+    "name": "롯데월드",
     "startDate": "2023-12-12T17:03:10",
     "endDate": "2023-12-13T17:03:10",
     "order": 3
@@ -23,7 +23,7 @@ Content-Type: application/json
   {
     "itineraryId": 3,
     "type": "LODGEMENT",
-    "item": "오사카성",
+    "name": "오사카성",
     "startDate": "2023-12-12T17:03:10",
     "endDate": "2023-12-14T17:03:10",
     "order": 2

--- a/src/test/java/com/fastcampus/toyproject/http_requests/trip/insert/trip-insert-success-1.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/trip/insert/trip-insert-success-1.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/api/user/1/trip
+POST http://localhost:8080/api/trip
 Content-Type: application/json
 
 {

--- a/src/test/java/com/fastcampus/toyproject/http_requests/trip/insert/trip-insert-success-2.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/trip/insert/trip-insert-success-2.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/api/user/1/trip
+POST http://localhost:8080/api/trip
 Content-Type: application/json
 
 {

--- a/src/test/java/com/fastcampus/toyproject/http_requests/trip/select/trip-getAll-sucess-1.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/trip/select/trip-getAll-sucess-1.http
@@ -1,2 +1,2 @@
-GET http://localhost:8080/api/user/1/trip/all
+GET http://localhost:8080/api/trip/all
 Accept: application/json


### PR DESCRIPTION
## 개요
여행 - 여정 관련 코드들 수정하고 개편했습니다. 

## 작업사항
1. 여정 - movement에 transportation 항목을 아예 삭제하였습니다. 
2. 그래서 굉장히 많은 부분에서 <b> 수정했습니다!! </b> 참고하세요 
3. 여정, 여행 서비스 부분 테스트 코드 작성했습니다. 
4. 여정 리스트 삽입 시 -> saveAll 로 성능 개선 
5. 여행 조회 시 삭제된 여행은 조회 안되도록 개선. 
6. 컨트롤러 api path 삭제했습니다. 
7. 전부 테스트 완료. 

## 기타 
서비스 부분 테스트 코드 작성했어요
Mock 안썼습니다. 

![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/59862752/b254a292-87d1-4d37-ae4b-05b4c94c2be4)

### 깃허브에는 mysql이랑 연동이 안되어 있어서, mock를 쓰지 않는 테스트인 경우에서는 빌드 fail이 뜹니다. 
### 그래서 일단 전부 주석처리했어요..!!! 

