### PR TITLE
[refactor] 토큰의 값을 가져오는 UserPrincipal 객체 생성

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
@@ -33,7 +33,8 @@ public class DefaultExceptionHandler {
      * @return
      */
     @ExceptionHandler(value = {
-        DefaultException.class
+        DefaultException.class,
+        SecurityException.class
     })
     public ResponseEntity<ErrorResponseDTO> handleDefaultException(
         DefaultException e,

--- a/src/main/java/com/fastcampus/toyproject/config/security/SecurityUtil.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/SecurityUtil.java
@@ -1,5 +1,9 @@
 package com.fastcampus.toyproject.config.security;
 
+import static com.fastcampus.toyproject.config.security.exception.SecurityExcpetionCode.INTENAL_SERVER_ERROR;
+
+import com.fastcampus.toyproject.config.security.exception.CustomSecurityException;
+import com.fastcampus.toyproject.config.security.exception.SecurityExcpetionCode;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -14,7 +18,7 @@ public class SecurityUtil {
             .getAuthentication();
 
         if (authentication == null || authentication.getName() == null) {
-            throw new RuntimeException("Security Context에 인증 정보가 없습니다.");
+            throw new CustomSecurityException(INTENAL_SERVER_ERROR);
         }
 
         return Long.parseLong(authentication.getName());

--- a/src/main/java/com/fastcampus/toyproject/config/security/exception/CustomSecurityException.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/exception/CustomSecurityException.java
@@ -1,0 +1,16 @@
+package com.fastcampus.toyproject.config.security.exception;
+
+import com.fastcampus.toyproject.common.exception.DefaultException;
+import com.fastcampus.toyproject.common.exception.ExceptionCode;
+
+public class CustomSecurityException extends DefaultException {
+
+    ExceptionCode errorCode;
+    String errorMsg;
+
+    public CustomSecurityException(SecurityExcpetionCode errorCode) {
+        super();
+        this.errorCode = errorCode;
+        this.errorMsg = errorCode.getMsg();
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/config/security/exception/SecurityExcpetionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/exception/SecurityExcpetionCode.java
@@ -1,0 +1,19 @@
+package com.fastcampus.toyproject.config.security.exception;
+
+import com.fastcampus.toyproject.common.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SecurityExcpetionCode implements ExceptionCode {
+
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "토큰에 권한 정보가 없습니다."),
+    BAD_TOKEN(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘 못 된 JWT 토큰입니다."),
+    INTENAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "Security Context에 인증 정보가 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String msg;
+}

--- a/src/main/java/com/fastcampus/toyproject/config/security/jwt/TokenProvider.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/jwt/TokenProvider.java
@@ -1,5 +1,9 @@
 package com.fastcampus.toyproject.config.security.jwt;
 
+import static com.fastcampus.toyproject.config.security.exception.SecurityExcpetionCode.INVALID_TOKEN;
+
+import com.fastcampus.toyproject.config.security.exception.CustomSecurityException;
+import com.fastcampus.toyproject.config.security.exception.SecurityExcpetionCode;
 import com.fastcampus.toyproject.domain.user.dto.TokenDto;
 import com.fastcampus.toyproject.domain.user.entity.Authority;
 import io.jsonwebtoken.Claims;
@@ -78,7 +82,7 @@ public class TokenProvider {
         Claims claims = parseClaims(accessToken);
 
         if (claims.get(AUTHORITIES_KEY) == null) {
-            throw new RuntimeException("권한 정보가 없는 토큰 입니다.");
+            throw new CustomSecurityException(INVALID_TOKEN);
         }
 
         Collection<? extends GrantedAuthority> authorities =
@@ -98,7 +102,7 @@ public class TokenProvider {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
-        } catch (SecurityException | MalformedJwtException e) {
+        } catch (CustomSecurityException | MalformedJwtException e) {
             log.info("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException e) {
             log.info("만료된 JWT 토큰입니다.");

--- a/src/main/java/com/fastcampus/toyproject/config/security/jwt/TokenProvider.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/jwt/TokenProvider.java
@@ -45,7 +45,7 @@ public class TokenProvider {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public TokenDto generateTokenDto(Authentication authentication) {
+    public TokenDto generateTokenDto(UserPrincipal authentication) {
 
         String authrities = authentication.getAuthorities().stream()
             .map(GrantedAuthority::getAuthority)
@@ -56,9 +56,11 @@ public class TokenProvider {
         Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
 
         String accessToken = Jwts.builder()
-            .setSubject(authentication.getName())
-            .claim(AUTHORITIES_KEY, authrities)
-            .claim("roles", Authority.ROLE_USER.getAuthority())
+            .setSubject(authentication.getEmail())
+            .claim("userId", authentication.getUserId())
+            .claim("email", authentication.getEmail())
+            .claim("name", authentication.getName())
+            .claim("roles", authentication.getAuthority())
             .setExpiration(accessTokenExpiresIn)
             .signWith(key, SignatureAlgorithm.HS256)
             .compact();
@@ -91,10 +93,11 @@ public class TokenProvider {
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
 
-        UserDetails principal = new User(claims.getSubject(), "", authorities);
+//        UserDetails principal = new User(claims.getSubject(), "", authorities);
 
-        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+        return new UserPrincipal(claims, authorities);
 
+//        return new UserPrincipal(authorities,)
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/com/fastcampus/toyproject/config/security/jwt/UserPrincipal.java
+++ b/src/main/java/com/fastcampus/toyproject/config/security/jwt/UserPrincipal.java
@@ -1,0 +1,61 @@
+package com.fastcampus.toyproject.config.security.jwt;
+
+import com.fastcampus.toyproject.domain.user.dto.UserResponseDTO;
+import com.fastcampus.toyproject.domain.user.entity.Authority;
+import com.fastcampus.toyproject.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
+import java.util.Collection;
+import javax.security.auth.Subject;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+public class UserPrincipal extends AbstractAuthenticationToken {
+
+    private Long userId;
+    private String email;
+    private String name;
+    private Authority authority;
+
+    /**
+     * Creates a token with the supplied array of authorities.
+     *
+     * @param authorities the collection of <tt>GrantedAuthority</tt>s for the principal represented by
+     *                    this authentication object.
+     */
+    public UserPrincipal(User user) {
+        super(null);
+        this.userId = user.getUserId();
+        this.email = user.getEmail();
+        this.name = user.getName();
+        this.authority = user.getAuthority();
+        setAuthenticated(false);
+    }
+
+    public UserPrincipal(Claims claims, Collection<? extends GrantedAuthority> authorities){
+        super(authorities);
+        this.userId = ((Number) claims.get("userId")).longValue();
+        this.email = String.valueOf(claims.get("email"));
+        this.name = String.valueOf(claims.get("name"));
+        setAuthenticated(false);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return "";
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return this.email;
+    }
+
+    @Override
+    public boolean implies(Subject subject) {
+        return super.implies(subject);
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/dto/UserResponseDTO.java
@@ -1,6 +1,7 @@
 package com.fastcampus.toyproject.domain.user.dto;
 
 
+import com.fastcampus.toyproject.domain.user.entity.Authority;
 import com.fastcampus.toyproject.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,12 +15,14 @@ public class UserResponseDTO {
     private Long userId;
     private String email;
     private String name;
+    private Authority authority;
 
     public static UserResponseDTO of(User user) {
         return UserResponseDTO.builder()
             .userId(user.getUserId())
             .email(user.getEmail())
             .name(user.getName())
+            .authority(user.getAuthority())
             .build();
 
     }

--- a/src/main/java/com/fastcampus/toyproject/domain/user/service/UserService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.fastcampus.toyproject.domain.user.service;
 
 import com.fastcampus.toyproject.common.BaseTimeEntity;
 import com.fastcampus.toyproject.config.security.jwt.TokenProvider;
+import com.fastcampus.toyproject.config.security.jwt.UserPrincipal;
 import com.fastcampus.toyproject.domain.user.dto.LoginDto;
 import com.fastcampus.toyproject.domain.user.dto.RefreshToken;
 import com.fastcampus.toyproject.domain.user.dto.TokenDto;
@@ -62,8 +63,7 @@ public class UserService {
 //            throw new RuntimeException("비밀번호가 틀립니다.");
 //        }
 
-        UsernamePasswordAuthenticationToken authentication =
-            loginDto.toAuthentication();
+        UserPrincipal authentication = new UserPrincipal(user);
 
         TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
 
@@ -92,7 +92,7 @@ public class UserService {
             throw new RuntimeException("토큰의 유저정보가 일치하지 않습니다.");
         }
 
-        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+        TokenDto tokenDto = tokenProvider.generateTokenDto((UserPrincipal) authentication);
 
         RefreshToken newRefreshToken = refreshToken.updateValue(tokenDto.getRefreshToken());
         refreshTokenRepository.save(newRefreshToken);


### PR DESCRIPTION
## 개요
토큰을 UserPrincipal 객체를 이용해서 가져오도록 수정하였습니다.

## 작업사항
스프링시큐리티에서 발생하는 에러를 CustomSecurityException 을 만들어서 공통으로 처리

스프링 시큐리티에서 제공하는 UsernamePasswordAthentication 어쩌구.. 엄청 긴거 있는데 
abstract 객체를 상속해서 UserPrincipal 객체를 만들었습니다.



## 사용방법
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/40512982/86fcc9eb-7812-4cf2-a67e-73d608a90a88)

컨트롤러에서 UserPrincipal 를 파라미터 적으면 됩니다.
현재 userId , email, name 을 가지고 있습니다.

## 기타
