### PR TITLE
[fix] defaultException의 생성자가 ExceptionCode 인터페이스를 매개변수로 받도록 설정

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultException.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultException.java
@@ -10,13 +10,13 @@ public class DefaultException extends RuntimeException {
     ExceptionCode errorCode;
     String errorMsg;
 
-    public DefaultException(DefaultExceptionCode errorCode, String errorMsg) {
+    public DefaultException(ExceptionCode errorCode, String errorMsg) {
         super(errorCode.getMsg());
         this.errorCode = errorCode;
         this.errorMsg = errorMsg;
     }
 
-    public DefaultException(DefaultExceptionCode errorCode) {
+    public DefaultException(ExceptionCode errorCode) {
         super(errorCode.getMsg());
         this.errorCode = errorCode;
         this.errorMsg = errorCode.getMsg();


### PR DESCRIPTION
## 개요
DefaultException 생성자가 ExceptionCode 인터페이스를 매개변수로 받도록 설정
## 작업사항
## 변경로직
### 변경후
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/40512982/9efaa90d-49e8-45be-9533-cbec8917284b)

## 사용방법

매개변수를 인터페이스로 변경해서 이제 ExceptionCode를 구현한 에러코드들을 매개변수로 쓸 수 있습니다.

## 기타
