### PR TITLE
[fix] 여행 삭제 부분 에러 수정 

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryExceptionCode.java
@@ -1,7 +1,9 @@
 package com.fastcampus.toyproject.domain.itinerary.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 import com.fastcampus.toyproject.common.exception.ExceptionCode;
@@ -14,7 +16,7 @@ import org.springframework.web.client.HttpServerErrorException.InternalServerErr
 @Getter
 public enum ItineraryExceptionCode implements ExceptionCode {
 
-    NO_ITINERARY(UNPROCESSABLE_ENTITY, "NO_ITINERARY", "해당되는 여정이 없습니다."),
+    NO_ITINERARY(NOT_FOUND, "NO_ITINERARY", "해당되는 여정이 없습니다."),
     ITINERARY_NOT_MATCH_TRIP(BAD_REQUEST, "ITINERARY_NOT_MATCH_TRIP", "여정과 여행이 일치하지 않습니다."),
     INCORRECT_ITINERARY_ORDER(BAD_REQUEST, "INCORRECT_ITINERARY_ORDER", "잘못된 여정 순서입니다."),
     DUPLICATE_ITINERARY_ORDER(BAD_REQUEST, "DUPLICATE_ITINERARY_ORDER","여정 순서가 중복됩니다."),
@@ -25,7 +27,7 @@ public enum ItineraryExceptionCode implements ExceptionCode {
     ILLEGAL_ITINERARY_TYPE(BAD_REQUEST, "ILLEGAL_ITINERARY_TYPE","잘 못 된 여정 타입입니다."),
     ITINERARY_ALREADY_DELETED(BAD_REQUEST, "ITINERARY_ALREADY_DELETED","이미 삭제된 여정입니다."),
     ITINERARY_SAVE_FAILED(INTERNAL_SERVER_ERROR, "ITINERARY_SAVE_FAILED", "여정 저장에 실패하였습니다."),
-    NOT_MATCH_BETWEEN_USER_AND_ITINERARY(UNPROCESSABLE_ENTITY, "NOT_MATCH_BETWEEN_USER_AND_ITINERARY", "로그인 유저와 여정 정보의 유저와 일치하지 않습니다.")
+    NOT_MATCH_BETWEEN_USER_AND_ITINERARY(FORBIDDEN, "NOT_MATCH_BETWEEN_USER_AND_ITINERARY", "로그인 유저와 여정 정보의 유저와 일치하지 않습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -121,12 +121,12 @@ public class TripController {
     @DeleteMapping("/{tripId}")
 
     public ResponseDTO<Void> deleteTrip(
-        UserPrincipal userPrincipal,
+        final UserPrincipal userPrincipal,
         @PathVariable final Long tripId
     ) {
         Long userId = userPrincipal.getUserId();
         log.info("TripController:: user ID : {} ", userId);
-        tripService.deleteTrip(tripId);
+        tripService.deleteTrip(userPrincipal.getUserId(), tripId);
         return ResponseDTO.ok("여행 삭제 완료");
 
     }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripExceptionCode.java
@@ -1,5 +1,7 @@
 package com.fastcampus.toyproject.domain.trip.exception;
 
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 import com.fastcampus.toyproject.common.exception.ExceptionCode;
@@ -10,9 +12,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum TripExceptionCode implements ExceptionCode {
-    NO_SUCH_TRIP(UNPROCESSABLE_ENTITY, "NO_SUCH_TRIP", "해당하는 여행 정보가 없습니다."),
-    TRIP_ALREADY_DELETED(UNPROCESSABLE_ENTITY, "TRIP_ALREADY_DELETED", "이미 삭제된 여행 정보입니다."),
-    NOT_MATCH_BETWEEN_USER_AND_TRIP(UNPROCESSABLE_ENTITY, "NOT_MATCH_BETWEEN_USER_AND_TRIP", "로그인 유저와 유저의 여행 정보가 일치하지 않습니다.")
+    NO_SUCH_TRIP(NOT_FOUND, "NO_SUCH_TRIP", "해당하는 여행 정보가 없습니다."),
+    TRIP_ALREADY_DELETED(FORBIDDEN, "TRIP_ALREADY_DELETED", "이미 삭제된 여행 정보입니다."),
+    NOT_MATCH_BETWEEN_USER_AND_TRIP(FORBIDDEN, "NOT_MATCH_BETWEEN_USER_AND_TRIP", "로그인 유저와 유저의 여행 정보가 일치하지 않습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/test/java/com/fastcampus/toyproject/domain/trip/TripControllerTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/trip/TripControllerTest.java
@@ -74,7 +74,7 @@ public class TripControllerTest {
 
 //    @Test
     public void deleteTripTest() throws Exception {
-        given(tripService.deleteTrip(anyLong(), anyLong())).willReturn(null);
+        given(tripService.deleteTrip(anyLong(), anyLong() )).willReturn(null);
 
         mockMvc.perform(delete("/api/member/1/trip/1"))
             .andDo(print())

--- a/src/test/java/com/fastcampus/toyproject/domain/trip/controller/TripControllerTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/trip/controller/TripControllerTest.java
@@ -86,7 +86,7 @@ class TripControllerTest {
 
 //    @Test
     public void deleteTripTest() throws Exception {
-        given(tripService.deleteTrip(anyLong())).willReturn(null);
+        given(tripService.deleteTrip(anyLong(), anyLong())).willReturn(null);
 
         mockMvc.perform(delete("/api/member/1/trip/1"))
             .andDo(print())


### PR DESCRIPTION
## 개요
- 여행 삭제에서 나타나는 에러 수정하엿습니다. 
- 여행, 여정에서 상황에 맞는 http code로 수정하였어요.

## 작업사항
### 변경후
유저 아이디와 트립의 유저 아이디가 일치 하지 않는 경우 -> <b> Forbidden </b>
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/59862752/f7ac61cc-cd34-4dc1-951b-c548c797316c)
옳지 않는 트립일 경우 -> <b> NOT found <b>
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/59862752/d0a014d0-aefc-4d32-a27d-6b329602bfa6)

## 사용방법
## 기타
