### PR TITLE
[feat & fix] 검색어 예외처리 추가 및 여행 상세 조회시 여정 순서들 정렬되도록 했습니다. 

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
@@ -76,6 +77,36 @@ public class DefaultExceptionHandler {
         return new ResponseEntity<>(
             ErrorResponseDTO.error(BAD_REQUEST),
             HttpStatus.BAD_REQUEST
+        );
+    }
+
+    /**
+     * @RequestParam valid 할 때 예외 처리
+     * @param e
+     * @param request
+     * @return
+     */
+    @ExceptionHandler(value = {
+        ConstraintViolationException.class
+    })
+    public ResponseEntity<ErrorResponseDTO> handleConstraintViolationException(
+            ConstraintViolationException e, HttpServletRequest request
+    ) {
+        log.error("ConstraintViolationException error url : {}, message : {}",
+                request.getRequestURI(),
+                e.getMessage()
+        );
+        //searchTripListByKeyword.keyword: 검색어를 채워주세요 -> "검색어를 채워주세요" 반환.
+        String[] msgList = e.getMessage().split(":");
+        String msg = msgList[msgList.length-1].substring(1);
+
+        return new ResponseEntity<>(
+                new ErrorResponseDTO(
+                        BAD_REQUEST.getStatus(),
+                        BAD_REQUEST.getCode(),
+                        msg
+                ),
+                HttpStatus.BAD_REQUEST
         );
     }
 

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -209,8 +209,11 @@ public class ItineraryService {
                 .findById(id)
                 .orElseThrow(() -> new ItineraryException(NO_ITINERARY));
             it.delete();
-            itineraryRepository.save(it);
-            deleteItList.add(ItineraryResponse.fromEntity(it));
+            Itinerary saveIt = itineraryRepository.save(it);
+            if (saveIt == null) {
+                throw new ItineraryException(ITINERARY_SAVE_FAILED);
+            }
+            deleteItList.add(ItineraryResponse.fromEntity(saveIt));
         }
 
         //3. 남은 여정들의 순서 재정의 - 여정 순서대로 entity 정렬
@@ -250,6 +253,10 @@ public class ItineraryService {
                 throw new ItineraryException(ITINERARY_NOT_MATCH_TRIP);
             }
             itinerary.update(req);
+            Itinerary saveIt = itineraryRepository.save(itinerary);
+            if (saveIt == null) {
+                throw new ItineraryException(ITINERARY_SAVE_FAILED);
+            }
         }
 
         return getItineraryResponseListByTrip(trip);

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -190,9 +190,7 @@ public class ItineraryService {
 
         //1. 해당 트립에, 삭제할 아이디들이 일단 존재하는지 확인.
         for (Long id : deleteIdList) {
-            Itinerary it = itineraryRepository
-                .findById(id)
-                .orElseThrow(() -> new ItineraryException(NO_ITINERARY));
+            Itinerary it = getItinerary(id);
             if (it.getTrip().getTripId() != tripId) {
                 throw new ItineraryException(NO_ITINERARY);
             }
@@ -205,9 +203,7 @@ public class ItineraryService {
 
         //2. 여정들 가져오기 (id만 적힌것들) -> delete 처리
         for (Long id : deleteIdList) {
-            Itinerary it = itineraryRepository
-                .findById(id)
-                .orElseThrow(() -> new ItineraryException(NO_ITINERARY));
+            Itinerary it = getItinerary(id);
             it.delete();
             Itinerary saveIt = itineraryRepository.save(it);
             if (saveIt == null) {
@@ -219,6 +215,13 @@ public class ItineraryService {
         //3. 남은 여정들의 순서 재정의 - 여정 순서대로 entity 정렬
         sortAgainItineraryOrder(getItineraryList(getTrip(tripId)));
         return deleteItList;
+    }
+
+    private Itinerary getItinerary(Long id) {
+        Itinerary it = itineraryRepository
+            .findById(id)
+            .orElseThrow(() -> new ItineraryException(NO_ITINERARY));
+        return it;
     }
 
     /**
@@ -246,8 +249,7 @@ public class ItineraryService {
         }
 
         for (ItineraryUpdateRequest req : itineraryUpdateRequests) {
-            Itinerary itinerary = itineraryRepository.findById(req.getItineraryId())
-                .orElseThrow(() -> new ItineraryException(NO_ITINERARY));
+            Itinerary itinerary = getItinerary(req.getItineraryId());
 
             if (!map.containsKey(req.getItineraryId())) {
                 throw new ItineraryException(ITINERARY_NOT_MATCH_TRIP);

--- a/src/main/java/com/fastcampus/toyproject/domain/reply/exception/ReplyException.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/reply/exception/ReplyException.java
@@ -6,16 +6,7 @@ import lombok.Getter;
 
 @Getter
 public class ReplyException extends DefaultException {
-
-    ExceptionCode exceptionCode;
-    String errorMsg;
-
-    public ReplyException(ReplyExceptionCode exceptionCode) {
+    public ReplyException(ExceptionCode exceptionCode) {
         super(exceptionCode);
-        this.exceptionCode = exceptionCode;
-        this.errorMsg = exceptionCode.getMsg();
     }
-
-
-
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -13,8 +13,10 @@ import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/trip")
 @Slf4j
+@Validated
 public class TripController {
 
     private final TripService tripService;
@@ -58,7 +61,7 @@ public class TripController {
     public ResponseDTO<List<TripResponse>> searchTripListByKeyword(
             @Valid @RequestParam("keyword")
             @NotBlank(message = "검색어를 채워주세요")
-            @Range(min = 1, max = 10, message = "검색어는 한 글자 이상이어야 합니다.")
+            @Length(min = 1, max = 10, message = "검색어는 한 글자 이상이어야 합니다.")
             final String keyword
     ) {
         log.info("keyword : {}", keyword);

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -56,28 +56,22 @@ public class TripController {
 
     @GetMapping("/search")
     public ResponseDTO<List<TripResponse>> searchTripListByKeyword(
-
             @Valid @RequestParam("keyword")
             @NotBlank(message = "검색어를 채워주세요")
             @Range(min = 1, max = 10, message = "검색어는 한 글자 이상이어야 합니다.")
             final String keyword
-
     ) {
-        System.out.println("keyword : " + keyword);
+        log.info("keyword : {}", keyword);
         Optional<List<TripResponse>> optional = tripService.getTripByKeyword(keyword);
         if (optional.get().size() == 0) {
-            return ResponseDTO.ok(
-                "검색된 여행이 없습니다.", null
-            );
+            return ResponseDTO.ok("검색된 여행이 없습니다.", optional.get());
         }
         return ResponseDTO.ok("여행 검색 완료", optional.get());
     }
 
     @PostMapping()
     public ResponseDTO<TripResponse> insertTrip(
-
-        UserPrincipal userPrincipal,
-
+        final UserPrincipal userPrincipal,
         @Valid @RequestBody final TripRequest tripRequest
     ) {
         DateUtil.isStartDateEarlierThanEndDate(
@@ -88,15 +82,12 @@ public class TripController {
         Long userId = userPrincipal.getUserId();
         log.info("TripController:: user ID : {} ", userPrincipal.getUserId());
         return ResponseDTO.ok("여행 삽입 완료",
-
             tripService.insertTrip(userId, tripRequest)
-
         );
     }
 
     @PutMapping("/{tripId}")
     public ResponseDTO<TripResponse> updateTrip(
-
         @PathVariable final Long tripId,
         final UserPrincipal userPrincipal,
         @Valid @RequestBody final TripRequest tripRequest
@@ -109,19 +100,14 @@ public class TripController {
         Long userId = userPrincipal.getUserId();
         log.info("TripController:: user ID : {} ", userId);
         return ResponseDTO.ok("여행 수정 완료",
-
             tripService.updateTrip(userId, tripId, tripRequest)
-
-        
-
         );
     }
 
 
     @DeleteMapping("/{tripId}")
-
     public ResponseDTO<Void> deleteTrip(
-        UserPrincipal userPrincipal,
+        final UserPrincipal userPrincipal,
         @PathVariable final Long tripId
     ) {
         Long userId = userPrincipal.getUserId();

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -61,7 +61,7 @@ public class TripController {
     public ResponseDTO<List<TripResponse>> searchTripListByKeyword(
             @Valid @RequestParam("keyword")
             @NotBlank(message = "검색어를 채워주세요")
-            @Length(min = 1, max = 15, message = "검색어는 한 글자 이상이어야 합니다.")
+            @Length(min = 1, max = 15, message = "검색어 길이는 1글자 ~ 15글자 사이어야 합니다.")
             final String keyword
     ) {
         log.info("keyword : {}", keyword);

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -76,7 +76,7 @@ public class TripController {
     @PostMapping()
     public ResponseDTO<TripResponse> insertTrip(
 
-        final UserPrincipal userPrincipal,
+        UserPrincipal userPrincipal,
 
         @Valid @RequestBody final TripRequest tripRequest
     ) {
@@ -121,7 +121,7 @@ public class TripController {
     @DeleteMapping("/{tripId}")
 
     public ResponseDTO<Void> deleteTrip(
-        final UserPrincipal userPrincipal,
+        UserPrincipal userPrincipal,
         @PathVariable final Long tripId
     ) {
         Long userId = userPrincipal.getUserId();

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -61,11 +61,11 @@ public class TripController {
     public ResponseDTO<List<TripResponse>> searchTripListByKeyword(
             @Valid @RequestParam("keyword")
             @NotBlank(message = "검색어를 채워주세요")
-            @Length(min = 1, max = 10, message = "검색어는 한 글자 이상이어야 합니다.")
+            @Length(min = 1, max = 15, message = "검색어는 한 글자 이상이어야 합니다.")
             final String keyword
     ) {
         log.info("keyword : {}", keyword);
-        Optional<List<TripResponse>> optional = tripService.getTripByKeyword(keyword);
+        Optional<List<TripResponse>> optional = tripService.getTripByKeyword(keyword.trim());
         if (optional.get().size() == 0) {
             return ResponseDTO.ok("검색된 여행이 없습니다.", optional.get());
         }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripExceptionCode.java
@@ -1,6 +1,7 @@
 package com.fastcampus.toyproject.domain.trip.exception;
 
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
@@ -15,7 +16,8 @@ public enum TripExceptionCode implements ExceptionCode {
 
     NO_SUCH_TRIP(NOT_FOUND, "NO_SUCH_TRIP", "해당하는 여행 정보가 없습니다."),
     TRIP_ALREADY_DELETED(FORBIDDEN, "TRIP_ALREADY_DELETED", "이미 삭제된 여행 정보입니다."),
-    NOT_MATCH_BETWEEN_USER_AND_TRIP(FORBIDDEN, "NOT_MATCH_BETWEEN_USER_AND_TRIP", "로그인 유저와 유저의 여행 정보가 일치하지 않습니다.")
+    NOT_MATCH_BETWEEN_USER_AND_TRIP(FORBIDDEN, "NOT_MATCH_BETWEEN_USER_AND_TRIP", "로그인 유저와 유저의 여행 정보가 일치하지 않습니다."),
+    TRIP_SAVE_FAILED(INTERNAL_SERVER_ERROR, "TRIP_SAVE_FAILED", "여행 저장에 실패하였습니다.")
 
     ;
 

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
@@ -4,19 +4,16 @@ package com.fastcampus.toyproject.domain.trip.service;
 import static com.fastcampus.toyproject.domain.trip.exception.TripExceptionCode.NOT_MATCH_BETWEEN_USER_AND_TRIP;
 import static com.fastcampus.toyproject.domain.trip.exception.TripExceptionCode.NO_SUCH_TRIP;
 import static com.fastcampus.toyproject.domain.trip.exception.TripExceptionCode.TRIP_ALREADY_DELETED;
+import static com.fastcampus.toyproject.domain.trip.exception.TripExceptionCode.TRIP_SAVE_FAILED;
 
 import com.fastcampus.toyproject.common.BaseTimeEntity;
-import com.fastcampus.toyproject.common.exception.DefaultException;
-import com.fastcampus.toyproject.common.exception.DefaultExceptionCode;
 import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
-import com.fastcampus.toyproject.domain.itinerary.service.ItineraryService;
 import com.fastcampus.toyproject.domain.trip.dto.TripDetailResponse;
 import com.fastcampus.toyproject.domain.trip.dto.TripRequest;
 import com.fastcampus.toyproject.domain.trip.dto.TripResponse;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fastcampus.toyproject.domain.trip.exception.TripException;
 import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
-import com.fastcampus.toyproject.domain.user.repository.UserRepository;
 import com.fastcampus.toyproject.domain.user.service.UserService;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +54,6 @@ public class TripService {
                 i--;
             }
         }
-
         return trip;
     }
 
@@ -118,10 +114,10 @@ public class TripService {
             .build();
 
         Trip saveTrip = tripRepository.save(trip);
-        if (saveTrip != null) {
-            return TripResponse.fromEntity(trip);
+        if (saveTrip == null) {
+            throw new TripException(TRIP_SAVE_FAILED);
         }
-        return null;
+        return TripResponse.fromEntity(trip);
     }
 
     /**
@@ -137,7 +133,12 @@ public class TripService {
         isMatchUserAndTrip(userId, existTrip);
 
         existTrip.updateFromDTO(tripRequest);
-        return TripResponse.fromEntity(tripRepository.save(existTrip));
+
+        Trip saveTrip = tripRepository.save(existTrip);
+        if (saveTrip == null) {
+            throw new TripException(TRIP_SAVE_FAILED);
+        }
+        return TripResponse.fromEntity(saveTrip);
     }
 
     /**
@@ -150,7 +151,12 @@ public class TripService {
         isMatchUserAndTrip(userId, existTrip);
 
         existTrip.delete();
-        return TripResponse.fromEntity(tripRepository.save(existTrip));
+
+        Trip saveTrip = tripRepository.save(existTrip);
+        if (saveTrip == null) {
+            throw new TripException(TRIP_SAVE_FAILED);
+        }
+        return TripResponse.fromEntity(saveTrip);
     }
 
     /**

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
@@ -14,7 +14,7 @@ import com.fastcampus.toyproject.domain.trip.dto.TripResponse;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fastcampus.toyproject.domain.trip.exception.TripException;
 import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
-import com.fastcampus.toyproject.domain.user.service.UserService;
+import com.fastcampus.toyproject.domain.user.repository.UserRepository;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
@@ -16,6 +16,8 @@ import com.fastcampus.toyproject.domain.trip.exception.TripException;
 import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
 import com.fastcampus.toyproject.domain.user.service.UserService;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -54,6 +56,7 @@ public class TripService {
                 i--;
             }
         }
+        Collections.sort(list, Comparator.comparingInt(Itinerary::getItineraryOrder));
         return trip;
     }
 


### PR DESCRIPTION
## 개요
1) 검색어 예외 처리 했습니다. 안 해도 된다 하셨지만,, 꼭 해보고 싶어서요! ㅎㅎ
2) 여행 상세 조회시, 여정 순서들이 정렬이 되지 않았습니다. 이 점 수정 했습니다. 
3) reply 클래스 예외처리 클래스 수정했어요.

## 작업사항
1) 검색어는 빈칸이면 안돼고, 1~15글자 사이어야 합니다. 
또한 "  일본" -> "일본" 으로 검색되게 했어요.
<img width="1123" alt="스크린샷 2023-11-15 오후 7 14 56" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/59862752/aaae9ba2-dfcf-4532-94f9-bd463ebc2963">
<img width="1106" alt="스크린샷 2023-11-15 오후 7 14 10" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/59862752/a3682c6c-e15b-429c-a1f2-2f9f40dd603f">


2) 여정 상세 조회시 여정 순서들도 모두 정렬되게 나오도록 수정했어요.
<img width="624" alt="스크린샷 2023-11-15 오후 7 19 02" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/59862752/ac36f598-8d54-491a-a9c2-962b740ffb8f">
