### PR TITLE
[fix] 여행 상세 조회시 좋아요, 댓글 같이 조회

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDetailResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDetailResponse.java
@@ -2,6 +2,7 @@ package com.fastcampus.toyproject.domain.trip.dto;
 
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponseFactory;
+import com.fastcampus.toyproject.domain.reply.dto.ReplyResponseDTO;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -28,7 +29,9 @@ public class TripDetailResponse {
     private LocalDate startDate;
     private LocalDate endDate;
     private Boolean isDomestic;
+    private Integer likeCount;
     private List<ItineraryResponse> itineraryList;
+    private List<ReplyResponseDTO> replyList;
 
     public static TripDetailResponse fromEntity(Trip trip) {
         return TripDetailResponse.builder()
@@ -38,12 +41,20 @@ public class TripDetailResponse {
             .startDate(trip.getStartDate())
             .endDate(trip.getEndDate())
             .isDomestic(trip.getIsDomestic())
+            .likeCount(trip.getLikesCount())
             .itineraryList(
                 Optional.ofNullable(trip.getItineraryList())
                     .orElse(new ArrayList<>())
                     .stream()
                     .map(ItineraryResponseFactory::getItineraryResponse)
                     .collect(Collectors.toList()))
+            .replyList(Optional.ofNullable(trip.getReplyList())
+                .orElse(new ArrayList<>())
+                .stream()
+                .filter(reply -> reply.getBaseTimeEntity().getDeletedAt() == null)
+                .map(ReplyResponseDTO::fromEntity)
+                .collect(Collectors.toList())
+            )
             .build();
     }
 }


### PR DESCRIPTION
## 개요
여행 상세조회시에 좋아요, 댓글 갯수 같이 조회

## 작업사항
Trip이 여행좋아요, 댓글리스트를 같이 가지고 있기 때문에
TripDetailResponse 에 필드만 추가 해도 잘 나오네요, 삭제된 댓글 안가져오는것도 확인 했습니다.

![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project3_DEV/assets/40512982/b63c81b9-ea85-4d02-9625-f2877fa75978)


## 기타
