### PR TITLE
[Feature] Reply Service, Repository, Controller 테스트 구현

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/domain/reply/dto/ReplyRequestDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/reply/dto/ReplyRequestDTO.java
@@ -1,8 +1,12 @@
 package com.fastcampus.toyproject.domain.reply.dto;
 
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class ReplyRequestDTO {
     private String content;
+
+
 }

--- a/src/test/java/com/fastcampus/toyproject/domain/reply/controller/ReplyControllerTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/reply/controller/ReplyControllerTest.java
@@ -1,0 +1,76 @@
+package com.fastcampus.toyproject.domain.reply.controller;
+
+import com.fastcampus.toyproject.config.security.jwt.UserPrincipal;
+import com.fastcampus.toyproject.domain.reply.dto.ReplyRequestDTO;
+import com.fastcampus.toyproject.domain.reply.dto.ReplyResponseDTO;
+import com.fastcampus.toyproject.domain.reply.service.ReplyService;
+import com.fastcampus.toyproject.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(SpringExtension.class)
+public class ReplyControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private ReplyService replyService;
+
+    @InjectMocks
+    private ReplyController replyController;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(replyController).build();
+    }
+
+    private UserPrincipal createUserPrincipal() {
+
+        User user = new User();
+        return new UserPrincipal(user);
+    }
+
+    @Test
+    public void testAddReply() throws Exception {
+        // Arrange
+        ReplyRequestDTO request = new ReplyRequestDTO();
+        request.setContent("테스트 댓글");
+
+        UserPrincipal userPrincipal = createUserPrincipal();
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(userPrincipal, null,
+                userPrincipal.getAuthorities()));
+
+        ReplyResponseDTO expectedResponse = ReplyResponseDTO.builder()
+            .replyId(123L)
+            .userId(userPrincipal.getUserId())
+            .tripId(456L)
+            .content("테스트 댓글")
+            .build();
+
+        given(replyService.addReply(userPrincipal.getUserId(), 456L,
+            request.getContent())).willReturn(expectedResponse);
+
+        String jsonRequest = "{\"content\": \"테스트 댓글\"}";
+
+        mockMvc.perform(post("/trip/456/reply")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonRequest))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.replyId").value(expectedResponse.getReplyId()));
+    }
+}

--- a/src/test/java/com/fastcampus/toyproject/domain/reply/repository/ReplyRepositoryTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/reply/repository/ReplyRepositoryTest.java
@@ -1,0 +1,73 @@
+package com.fastcampus.toyproject.domain.reply.repository;
+
+import com.fastcampus.toyproject.domain.reply.entity.Reply;
+import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
+import com.fastcampus.toyproject.domain.user.entity.User;
+import com.fastcampus.toyproject.domain.user.entity.Authority;
+import com.fastcampus.toyproject.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class ReplyRepositoryTest {
+
+    @Autowired
+    private ReplyRepository replyRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TripRepository tripRepository;
+
+    private User user;
+    private Trip trip;
+
+    @BeforeEach
+    public void setUp() {
+        user = User.builder()
+            .email("user@example.com")
+            .password("password")
+            .name("Test User")
+            .authority(Authority.ROLE_USER)
+            .build();
+        userRepository.save(user);
+
+        trip = Trip.builder()
+            .tripName("Test Trip")
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusDays(1))
+            .isDomestic(true)
+            .user(user)
+            .build();
+        tripRepository.save(trip);
+
+        Reply reply = Reply.builder()
+            .user(user)
+            .trip(trip)
+            .content("댓글 내용 test")
+            .build();
+        replyRepository.save(reply);
+    }
+
+    @Test
+    public void findAllByTripTripId_ReturnsReplyList() {
+        List<Reply> replies = replyRepository.findAllByTripTripId(trip.getTripId());
+        assertThat(replies).isNotEmpty();
+        assertThat(replies).hasSize(1);
+        Reply reply = replies.get(0);
+        assertThat(reply.getUser()).isEqualTo(user);
+        assertThat(reply.getTrip()).isEqualTo(trip);
+        assertThat(reply.getContent()).isEqualTo("댓글 내용 test");
+    }
+}

--- a/src/test/java/com/fastcampus/toyproject/domain/reply/service/ReplyServiceTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/reply/service/ReplyServiceTest.java
@@ -1,0 +1,67 @@
+package com.fastcampus.toyproject.domain.reply.service;
+
+import com.fastcampus.toyproject.domain.reply.dto.ReplyResponseDTO;
+import com.fastcampus.toyproject.domain.reply.entity.Reply;
+
+import com.fastcampus.toyproject.domain.reply.repository.ReplyRepository;
+import com.fastcampus.toyproject.domain.trip.entity.Trip;
+
+import com.fastcampus.toyproject.domain.trip.service.TripService;
+import com.fastcampus.toyproject.domain.user.entity.User;
+import com.fastcampus.toyproject.domain.user.service.UserService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ReplyServiceTest {
+
+    @InjectMocks
+    private ReplyService replyService;
+
+    @Mock
+    private ReplyRepository replyRepository;
+
+    @Mock
+    private TripService tripService;
+
+    @Mock
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void testAddReply() {
+
+        Long userId = 1L;
+        Long tripId = 2L;
+        String content = "Test reply content";
+
+        User user = User.builder().userId(userId).build();
+        Trip trip = Trip.builder().tripId(tripId).build();
+        Reply reply = Reply.builder().user(user).trip(trip).content(content).build();
+
+        when(userService.getUser(userId)).thenReturn(user);
+        when(tripService.getTripByTripId(tripId)).thenReturn(trip);
+        when(replyRepository.save(any())).thenReturn(reply);
+
+        ReplyResponseDTO responseDTO = replyService.addReply(userId, tripId, content);
+
+        assertThat(responseDTO).isNotNull();
+        assertThat(responseDTO.getUserId()).isEqualTo(userId);
+        assertThat(responseDTO.getTripId()).isEqualTo(tripId);
+        assertThat(responseDTO.getContent()).isEqualTo(content);
+    }
+
+
+}

--- a/src/test/java/com/fastcampus/toyproject/domain/reply/service/ReplyServiceTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/reply/service/ReplyServiceTest.java
@@ -1,16 +1,19 @@
 package com.fastcampus.toyproject.domain.reply.service;
 
+
 import com.fastcampus.toyproject.domain.reply.dto.ReplyResponseDTO;
 import com.fastcampus.toyproject.domain.reply.entity.Reply;
-
+import com.fastcampus.toyproject.domain.reply.exception.ReplyException;
+import com.fastcampus.toyproject.domain.reply.exception.ReplyExceptionCode;
 import com.fastcampus.toyproject.domain.reply.repository.ReplyRepository;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
-
 import com.fastcampus.toyproject.domain.trip.service.TripService;
 import com.fastcampus.toyproject.domain.user.entity.User;
 import com.fastcampus.toyproject.domain.user.service.UserService;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -41,6 +44,7 @@ class ReplyServiceTest {
     }
 
     @Test
+    @DisplayName("댓글을 추가")
     void testAddReply() {
 
         Long userId = 1L;
@@ -61,6 +65,26 @@ class ReplyServiceTest {
         assertThat(responseDTO.getUserId()).isEqualTo(userId);
         assertThat(responseDTO.getTripId()).isEqualTo(tripId);
         assertThat(responseDTO.getContent()).isEqualTo(content);
+    }
+
+
+    @Test
+    @DisplayName("댓글을 삭제")
+    void testDeleteReplyNotFound() {
+
+        Long userId = 1L;
+        Long replyId = 2L;
+
+        when(replyRepository.findById(replyId)).thenReturn(Optional.empty());
+
+        ReplyException exception = org.junit.jupiter.api.Assertions.assertThrows(
+            ReplyException.class,
+            () -> replyService.deleteReply(userId, replyId)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ReplyExceptionCode.REPLY_NOT_FOUND);
+
+        verify(replyRepository, never()).save(any());
     }
 
 


### PR DESCRIPTION
## [Feature] Reply Service, Repository, Controller 테스트 구현
- ReplyService를 테스트하는 단위테스트 ReplyServiceTest 추가
- ReplyRepository를 테스트하는 단위테스트 ReplyRepositoryTest 추가
- ReplyController를 테스트하는 단위테스트 ReplyControllerTest 추가

----
[문제 사항]
- ReplyController에서 LikeTripController와 동일한 에러가 발생해 일단 주석 처리하고 커밋했습니다. 